### PR TITLE
Fix license generation output paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "update-changelog": "git-cliff -c ./cliff.toml -o CHANGELOG.md",
     "clean:debug": "bash debug/cleanDevFiles.sh",
     "find-deadcode": "ts-prune",
-    "license-check:generate": "license-checker --production --json --out src/assets/licenses.json",
+    "license-check:generate": "nlx tsx scripts/generate-licenses.mts",
     "license-check:validate": "license-checker --production --failOn 'GPL;GPL-2.0;GPL-3.0;LGPL;LGPL-3.0;AGPL;AGPL-3.0;AGPL-3.0-only;'",
     "test": "nr vitest run",
     "test:web": "vitest run --project web",

--- a/scripts/generate-licenses.mts
+++ b/scripts/generate-licenses.mts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+/**
+ * # ライセンス情報生成スクリプト
+ *
+ * `license-checker` の結果から環境依存のパスを除外し、
+ * `src/assets/licenses.json` を生成する。
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import licenseChecker from 'license-checker';
+
+const rootDir = process.cwd();
+
+interface PackageInfo {
+  path?: string;
+  licenseFile?: string;
+  [key: string]: unknown;
+}
+
+licenseChecker.init(
+  {
+    start: rootDir,
+    production: true,
+    json: true,
+    relativeLicensePath: true,
+  },
+  (err, packages) => {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    }
+
+    for (const pkg of Object.values(packages) as PackageInfo[]) {
+      if (pkg.path) pkg.path = path.relative(rootDir, pkg.path);
+      if (pkg.licenseFile)
+        pkg.licenseFile = path.relative(rootDir, pkg.licenseFile);
+    }
+
+    const outputPath = path.resolve('src/assets/licenses.json');
+    fs.writeFileSync(outputPath, JSON.stringify(packages, null, 2));
+  },
+);


### PR DESCRIPTION
## Summary
- generate license JSON without absolute paths
- update license-check:generate script

## Testing
- `yarn lint`
- `yarn test` *(fails: FetchError: getaddrinfo ENOTFOUND api.vrchat.cloud)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the license generation process to use a new script for producing license information. This change does not affect application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->