### PR TITLE
Add docstrings for reusable components

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -40,6 +40,11 @@ interface ButtonProps
   asChild?: boolean;
 }
 
+/**
+ * 各種画面で利用されるスタイリング済みのボタンコンポーネント。
+ * `variant` や `size` により見た目を変更でき、`AppHeader` や設定画面など
+ * 幅広いコンポーネントで使われている。
+ */
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -6,6 +6,10 @@ import * as React from 'react';
 
 import { cn } from '../lib/utils'; // パス修正
 
+/**
+ * Radix UI を利用したカスタムチェックボックス。
+ * データベース操作用の設定画面などで選択の有無を入力するために使われる。
+ */
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,6 +2,10 @@ import * as React from 'react';
 
 import { cn } from '../lib/utils';
 
+/**
+ * フォームや検索欄で使用される標準的な入力フィールド。
+ * `PhotoGallery/Header` など複数の画面で文字入力を受け付けるために利用する。
+ */
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
   ({ className, type, ...props }, ref) => {
     return (

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -8,6 +8,10 @@ const labelVariants = cva(
   'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
 );
 
+/**
+ * 入力欄などの説明に使用されるラベルコンポーネント。
+ * 設定画面やモーダル内のフォームでテキストを添えるために利用する。
+ */
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -3,6 +3,10 @@ import * as React from 'react';
 
 import { cn } from '../lib/utils';
 
+/**
+ * オーバーフローする内容をスクロール可能にするコンテナ。
+ * 長文の規約表示など `TermsModal` で利用されている。
+ */
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
@@ -21,6 +25,10 @@ const ScrollArea = React.forwardRef<
 ));
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
+/**
+ * `ScrollArea` 内で使用するカスタムスクロールバー。
+ * 横向き・縦向き両方に対応し、ユーザーが内容をスクロールできるようにする。
+ */
 const ScrollBar = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -1,5 +1,10 @@
 import type { trpcReact } from '@/trpc';
 
+/**
+ * 写真ギャラリー関連の tRPC クエリを再取得させるためのユーティリティ関数。
+ * `PathSettings` や `PhotoGallery/Header` などから呼び出され、
+ * データ更新後にキャッシュを無効化して UI を最新状態に保つ。
+ */
 export const invalidatePhotoGalleryQueries = (
   trpsUtils: ReturnType<typeof trpcReact.useUtils>,
 ) => {

--- a/src/trpcWrapper.tsx
+++ b/src/trpcWrapper.tsx
@@ -7,6 +7,11 @@ import superjson from 'superjson';
 
 import { trpcReact } from './trpc';
 
+/**
+ * tRPC クライアントと React Query の QueryClient を初期化し、
+ * アプリ全体にプロバイダーを提供するラッパーコンポーネント。
+ * `App.tsx` のルートで使用され、API 通信とキャッシュ管理を行う環境を整える。
+ */
 export default ({ children }: { children: React.ReactNode }) => {
   const handleError = (error: Error) => {
     window.Main.sendErrorMessage(

--- a/src/v2/utils/colorExtractor.ts
+++ b/src/v2/utils/colorExtractor.ts
@@ -1,3 +1,7 @@
+/**
+ * 画像要素をキャンバスに描画し、そのピクセルデータを取得するヘルパー。
+ * `extractDominantColors` からのみ利用される内部関数。
+ */
 function getPixelData(img: HTMLImageElement): ImageData {
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');
@@ -51,6 +55,10 @@ interface ColorBucket {
   hsl: [number, number, number];
 }
 
+/**
+ * 与えられた画像から主要な色を抽出する関数。
+ * `BoldPreview` や `previewGenerator` で背景色を決定するために使われる。
+ */
 export function extractDominantColors(img: HTMLImageElement) {
   const imageData = getPixelData(img);
   const data = imageData.data;


### PR DESCRIPTION
## Summary
- document `invalidatePhotoGalleryQueries` helper
- add description for `TrpcWrapper`
- document several UI components (Button, Checkbox, Input, Label, ScrollArea, ScrollBar)
- describe color extraction helpers

## Testing
- `yarn lint` *(fails: tunneling socket could not be established)*
- `yarn test` *(fails: getaddrinfo ENOTFOUND api.vrchat.cloud)*

------
https://chatgpt.com/codex/tasks/task_e_683bfbee70f08328a5bf2ef25d6ba8e9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added descriptive JSDoc comments to various components and utility functions, providing clear explanations of their purpose and typical usage. No changes were made to the functionality or behavior of any components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->