### PR TITLE
feat: Remember window size and position

### DIFF
--- a/electron/electronUtil.ts
+++ b/electron/electronUtil.ts
@@ -12,14 +12,14 @@ import {
   Tray,
   app,
   ipcMain,
-  shell,
   screen, // Ensure screen is imported
+  shell,
 } from 'electron';
 import isDev from 'electron-is-dev';
 
-// Local
-import { getSettingStore, type SettingStore } from './module/settingStore'; // Import the type
 import { logger } from './lib/logger';
+// Local
+import { type SettingStore, getSettingStore } from './module/settingStore'; // Import the type
 
 let settingStore: SettingStore | null = null;
 
@@ -41,8 +41,8 @@ function createWindow(): BrowserWindow {
   const savedBounds = settingStore.getWindowBounds(); // Uncomment and use this
 
   // Default width and height if no saved bounds
-  let width = WINDOW_CONFIG.DEFAULT_WIDTH;
-  let height = WINDOW_CONFIG.DEFAULT_HEIGHT;
+  let width: number = WINDOW_CONFIG.DEFAULT_WIDTH;
+  let height: number = WINDOW_CONFIG.DEFAULT_HEIGHT;
   let x: number | undefined = undefined;
   let y: number | undefined = undefined;
 
@@ -51,14 +51,26 @@ function createWindow(): BrowserWindow {
     const { workArea } = primaryDisplay;
 
     // Restore size, ensuring it's not smaller than min size and not larger than work area
-    width = Math.max(WINDOW_CONFIG.MIN_WIDTH, Math.min(savedBounds.width, workArea.width));
-    height = Math.max(WINDOW_CONFIG.MIN_HEIGHT, Math.min(savedBounds.height, workArea.height));
+    width = Math.max(
+      WINDOW_CONFIG.MIN_WIDTH,
+      Math.min(savedBounds.width, workArea.width),
+    );
+    height = Math.max(
+      WINDOW_CONFIG.MIN_HEIGHT,
+      Math.min(savedBounds.height, workArea.height),
+    );
 
     // Restore position, ensuring it's within the work area
     // Adjust if the window would be off-screen
     if (savedBounds.x !== undefined && savedBounds.y !== undefined) {
-        x = Math.max(workArea.x, Math.min(savedBounds.x, workArea.x + workArea.width - width));
-        y = Math.max(workArea.y, Math.min(savedBounds.y, workArea.y + workArea.height - height));
+      x = Math.max(
+        workArea.x,
+        Math.min(savedBounds.x, workArea.x + workArea.width - width),
+      );
+      y = Math.max(
+        workArea.y,
+        Math.min(savedBounds.y, workArea.y + workArea.height - height),
+      );
     }
   }
 
@@ -135,7 +147,9 @@ function createWindow(): BrowserWindow {
   mainWindow.on('close', () => {
     if (!settingStore) {
       // It's unlikely to reach here if createWindow succeeded, but good for safety
-      logger.error('settingStore not initialized in mainWindow close event');
+      logger.error({
+        message: 'settingStore not initialized in mainWindow close event',
+      });
       return;
     }
     const bounds = mainWindow.getBounds();
@@ -161,14 +175,18 @@ function createWindow(): BrowserWindow {
         currentDisplay.workArea.x, // Ensure x is within workArea.x
         Math.min(
           currentBounds.x,
-          currentDisplay.workArea.x + currentDisplay.workAreaSize.width - currentBounds.width,
+          currentDisplay.workArea.x +
+            currentDisplay.workAreaSize.width -
+            currentBounds.width,
         ),
       ),
       y: Math.max(
         currentDisplay.workArea.y, // Ensure y is within workArea.y
         Math.min(
           currentBounds.y,
-          currentDisplay.workArea.y + currentDisplay.workAreaSize.height - currentBounds.height,
+          currentDisplay.workArea.y +
+            currentDisplay.workAreaSize.height -
+            currentBounds.height,
         ),
       ),
     };
@@ -295,13 +313,12 @@ const setTray = () => {
 };
 import { match } from 'ts-pattern';
 import { loadLogInfoIndexFromVRChatLog } from './module/logInfo/service';
-import type { getSettingStore } from './module/settingStore';
 /**
  * 一定間隔でログ処理を実行するタイマーイベントを設定する。
  * バックグラウンド処理が有効な場合のみログを読み込み通知を送る。
  */
 const setTimeEventEmitter = (
-  setTimeEventEmitter(passedSettingStore: ReturnType<typeof getSettingStore>) // Renamed to avoid conflict
+  passedSettingStore: ReturnType<typeof getSettingStore>,
 ) => {
   const intervalEventEmitter = new EventEmitter();
   // 6時間ごとに実行
@@ -313,7 +330,8 @@ const setTimeEventEmitter = (
   );
 
   intervalEventEmitter.on('time', async (now: Date) => {
-    if (!passedSettingStore.getBackgroundFileCreateFlag()) { // Use passedSettingStore
+    if (!passedSettingStore.getBackgroundFileCreateFlag()) {
+      // Use passedSettingStore
       logger.debug('バックグラウンド処理が無効になっています');
       return;
     }

--- a/electron/electronUtil.ts
+++ b/electron/electronUtil.ts
@@ -13,11 +13,15 @@ import {
   app,
   ipcMain,
   shell,
+  screen, // Ensure screen is imported
 } from 'electron';
 import isDev from 'electron-is-dev';
 
 // Local
+import { getSettingStore } from './module/settingStore';
 import { logger } from './lib/logger';
+
+const settingStore = getSettingStore();
 
 const WINDOW_CONFIG = {
   DEFAULT_WIDTH: 1024,
@@ -31,45 +35,35 @@ const WINDOW_CONFIG = {
  * 既存のウィンドウがなければ初期サイズで作成する。
  */
 function createWindow(): BrowserWindow {
-  const savedBounds = null; //settingStore.getWindowBounds();
+  const savedBounds = settingStore.getWindowBounds(); // Uncomment and use this
 
-  const { width, height } = savedBounds || {
-    width: WINDOW_CONFIG.DEFAULT_WIDTH,
-    height: WINDOW_CONFIG.DEFAULT_HEIGHT,
-  };
+  // Default width and height if no saved bounds
+  let width = WINDOW_CONFIG.DEFAULT_WIDTH;
+  let height = WINDOW_CONFIG.DEFAULT_HEIGHT;
+  let x: number | undefined = undefined;
+  let y: number | undefined = undefined;
 
-  // 保存された位置に最も近いディスプレイを取得
-  // const nearestDisplay = savedBounds
-  //   ? screen.getDisplayNearestPoint({ x: savedBounds.x, y: savedBounds.y })
-  //   : screen.getPrimaryDisplay();
+  if (savedBounds) {
+    const primaryDisplay = screen.getPrimaryDisplay();
+    const { workArea } = primaryDisplay;
 
-  // const workAreaSize = nearestDisplay.workArea;
+    // Restore size, ensuring it's not smaller than min size and not larger than work area
+    width = Math.max(WINDOW_CONFIG.MIN_WIDTH, Math.min(savedBounds.width, workArea.width));
+    height = Math.max(WINDOW_CONFIG.MIN_HEIGHT, Math.min(savedBounds.height, workArea.height));
 
-  // ウィンドウサイズを画面サイズに合わせて調整
-  // const width = Math.min(
-  //   savedBounds?.width || WINDOW_CONFIG.DEFAULT_WIDTH,
-  //   workAreaSize.width,
-  // );
-  // const height = Math.min(
-  //   savedBounds?.height || WINDOW_CONFIG.DEFAULT_HEIGHT,
-  //   workAreaSize.height,
-  // );
-
-  // ウィンドウ位置が画面外にはみ出していないか確認
-  // const x =
-  //   savedBounds?.x !== undefined
-  //     ? Math.max(0, Math.min(savedBounds.x, workAreaSize.width - width))
-  //     : undefined;
-  // const y =
-  //   savedBounds?.y !== undefined
-  //     ? Math.max(0, Math.min(savedBounds.y, workAreaSize.height - height))
-  //     : undefined;
+    // Restore position, ensuring it's within the work area
+    // Adjust if the window would be off-screen
+    if (savedBounds.x !== undefined && savedBounds.y !== undefined) {
+        x = Math.max(workArea.x, Math.min(savedBounds.x, workArea.x + workArea.width - width));
+        y = Math.max(workArea.y, Math.min(savedBounds.y, workArea.y + workArea.height - height));
+    }
+  }
 
   const mainWindow = new BrowserWindow({
     width,
     height,
-    // x,
-    // y,
+    x, // Use x from savedBounds or undefined
+    y, // Use y from savedBounds or undefined
     minWidth: WINDOW_CONFIG.MIN_WIDTH,
     minHeight: WINDOW_CONFIG.MIN_HEIGHT,
     frame: false,
@@ -136,43 +130,43 @@ function createWindow(): BrowserWindow {
 
   // ウィンドウの状態を保存
   mainWindow.on('close', () => {
-    // const bounds = mainWindow.getBounds();
-    // settingStore.setWindowBounds(bounds);
+    const bounds = mainWindow.getBounds();
+    settingStore.setWindowBounds(bounds);
   });
 
   // ディスプレイ構成が変更された時のハンドリング
-  // screen.on('display-metrics-changed', () => {
-  //   const currentBounds = mainWindow.getBounds();
-  //   const currentDisplay = screen.getDisplayNearestPoint({
-  //     x: currentBounds.x,
-  //     y: currentBounds.y,
-  //   });
+  screen.on('display-metrics-changed', () => {
+    const currentBounds = mainWindow.getBounds();
+    const currentDisplay = screen.getDisplayNearestPoint({
+      x: currentBounds.x,
+      y: currentBounds.y,
+    });
 
-  //   // ウィンドウが表示可能な領域に収まるように調整
-  //   const adjustedBounds = {
-  //     width: Math.min(currentBounds.width, currentDisplay.workAreaSize.width),
-  //     height: Math.min(
-  //       currentBounds.height,
-  //       currentDisplay.workAreaSize.height,
-  //     ),
-  //     x: Math.max(
-  //       0,
-  //       Math.min(
-  //         currentBounds.x,
-  //         currentDisplay.workAreaSize.width - currentBounds.width,
-  //       ),
-  //     ),
-  //     y: Math.max(
-  //       0,
-  //       Math.min(
-  //         currentBounds.y,
-  //         currentDisplay.workAreaSize.height - currentBounds.height,
-  //       ),
-  //     ),
-  //   };
+    // ウィンドウが表示可能な領域に収まるように調整
+    const adjustedBounds = {
+      width: Math.min(currentBounds.width, currentDisplay.workAreaSize.width),
+      height: Math.min(
+        currentBounds.height,
+        currentDisplay.workAreaSize.height,
+      ),
+      x: Math.max(
+        currentDisplay.workArea.x, // Ensure x is within workArea.x
+        Math.min(
+          currentBounds.x,
+          currentDisplay.workArea.x + currentDisplay.workAreaSize.width - currentBounds.width,
+        ),
+      ),
+      y: Math.max(
+        currentDisplay.workArea.y, // Ensure y is within workArea.y
+        Math.min(
+          currentBounds.y,
+          currentDisplay.workArea.y + currentDisplay.workAreaSize.height - currentBounds.height,
+        ),
+      ),
+    };
 
-  //   mainWindow.setBounds(adjustedBounds);
-  // });
+    mainWindow.setBounds(adjustedBounds);
+  });
 
   return mainWindow;
 }

--- a/electron/index.ts
+++ b/electron/index.ts
@@ -12,6 +12,7 @@ import unhandled from 'electron-unhandled';
 import { scrubEventData } from '../src/lib/utils/masking';
 import { router } from './api';
 import * as electronUtil from './electronUtil';
+import { initializeSettingStoreForUtil } from './electronUtil';
 import { logger } from './lib/logger';
 import * as sequelizeClient from './lib/sequelize';
 import { getAppUserDataPath } from './lib/wrappedApp';
@@ -19,6 +20,7 @@ import { getBackgroundUsecase } from './module/backGroundUsecase';
 import { initSettingStore } from './module/settingStore';
 
 const settingStore = initSettingStore();
+initializeSettingStoreForUtil();
 
 export let isSentryInitializedMain = false; // Sentry初期化フラグ exportする
 

--- a/src/assets/licenses.json
+++ b/src/assets/licenses.json
@@ -175,11 +175,11 @@
     "path": "node_modules/@electron/get",
     "licenseFile": "node_modules/@electron/get/LICENSE"
   },
-  "@esbuild/linux-arm64@0.21.5": {
+  "@esbuild/linux-x64@0.21.5": {
     "licenses": "MIT",
     "repository": "https://github.com/evanw/esbuild",
-    "path": "node_modules/@esbuild/linux-arm64",
-    "licenseFile": "node_modules/@esbuild/linux-arm64/README.md"
+    "path": "node_modules/@esbuild/linux-x64",
+    "licenseFile": "node_modules/@esbuild/linux-x64/README.md"
   },
   "@fastify/otel@0.8.0": {
     "licenses": "MIT",
@@ -225,21 +225,21 @@
     "path": "node_modules/@gar/promisify",
     "licenseFile": "node_modules/@gar/promisify/LICENSE.md"
   },
-  "@img/sharp-libvips-linux-arm64@1.0.2": {
+  "@img/sharp-libvips-linux-x64@1.0.2": {
     "licenses": "LGPL-3.0-or-later",
     "repository": "https://github.com/lovell/sharp-libvips",
     "publisher": "Lovell Fuller",
     "email": "npm@lovell.info",
-    "path": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm64",
-    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm64/README.md"
+    "path": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-x64",
+    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-x64/README.md"
   },
-  "@img/sharp-linux-arm64@0.33.3": {
+  "@img/sharp-linux-x64@0.33.3": {
     "licenses": "Apache-2.0",
     "repository": "https://github.com/lovell/sharp",
     "publisher": "Lovell Fuller",
     "email": "npm@lovell.info",
-    "path": "node_modules/sharp/node_modules/@img/sharp-linux-arm64",
-    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-linux-arm64/LICENSE"
+    "path": "node_modules/sharp/node_modules/@img/sharp-linux-x64",
+    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-linux-x64/LICENSE"
   },
   "@isaacs/cliui@8.0.2": {
     "licenses": "ISC",
@@ -816,12 +816,12 @@
     "path": "node_modules/@radix-ui/rect",
     "licenseFile": "node_modules/@radix-ui/rect/README.md"
   },
-  "@rollup/rollup-linux-arm64-gnu@4.40.0": {
+  "@rollup/rollup-linux-x64-gnu@4.40.0": {
     "licenses": "MIT",
     "repository": "https://github.com/rollup/rollup",
     "publisher": "Lukas Taegert-Atkinson",
-    "path": "node_modules/@rollup/rollup-linux-arm64-gnu",
-    "licenseFile": "node_modules/@rollup/rollup-linux-arm64-gnu/README.md"
+    "path": "node_modules/@rollup/rollup-linux-x64-gnu",
+    "licenseFile": "node_modules/@rollup/rollup-linux-x64-gnu/README.md"
   },
   "@sentry-internal/browser-utils@9.18.0": {
     "licenses": "MIT",
@@ -872,17 +872,17 @@
     "path": "node_modules/@sentry/bundler-plugin-core",
     "licenseFile": "node_modules/@sentry/bundler-plugin-core/LICENSE"
   },
-  "@sentry/cli-linux-arm64@2.42.2": {
+  "@sentry/cli-linux-x64@2.42.2": {
     "licenses": "BSD-3-Clause",
     "repository": "https://github.com/getsentry/sentry-cli",
-    "path": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-arm64",
-    "licenseFile": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-arm64/README.md"
+    "path": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-x64",
+    "licenseFile": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-x64/README.md"
   },
-  "@sentry/cli-linux-arm64@2.45.0": {
+  "@sentry/cli-linux-x64@2.45.0": {
     "licenses": "BSD-3-Clause",
     "repository": "https://github.com/getsentry/sentry-cli",
-    "path": "node_modules/@sentry/cli-linux-arm64",
-    "licenseFile": "node_modules/@sentry/cli-linux-arm64/README.md"
+    "path": "node_modules/@sentry/cli-linux-x64",
+    "licenseFile": "node_modules/@sentry/cli-linux-x64/README.md"
   },
   "@sentry/cli@2.42.2": {
     "licenses": "BSD-3-Clause",
@@ -1586,11 +1586,11 @@
     "path": "node_modules/clean-stack",
     "licenseFile": "node_modules/clean-stack/license"
   },
-  "clip-filepaths-linux-arm64-gnu@0.2.0": {
+  "clip-filepaths-linux-x64-gnu@0.2.0": {
     "licenses": "MIT",
     "repository": "https://github.com/tktcorporation/clip-filepaths",
-    "path": "node_modules/clip-filepaths-linux-arm64-gnu",
-    "licenseFile": "node_modules/clip-filepaths-linux-arm64-gnu/README.md"
+    "path": "node_modules/clip-filepaths-linux-x64-gnu",
+    "licenseFile": "node_modules/clip-filepaths-linux-x64-gnu/README.md"
   },
   "clip-filepaths@0.2.0": {
     "licenses": "MIT",
@@ -4584,7 +4584,7 @@
     "path": "node_modules/vite",
     "licenseFile": "node_modules/vite/LICENSE.md"
   },
-  "vrchat-albums@0.12.1": {
+  "vrchat-albums@0.13.0": {
     "licenses": "MIT*",
     "repository": "https://github.com/tktcorporation/vrchat-albums",
     "publisher": "tktcorporation",


### PR DESCRIPTION
Implemented saving and restoring of the application window's size and position.

- Modified `electron/electronUtil.ts` to use `settingStore` for persisting window bounds.
- Window bounds (x, y, width, height) are loaded when the window is created, ensuring the window appears within the screen's work area.
- Window bounds are saved when the window is closed.
- Imported `getSettingStore` and `screen` in `electron/electronUtil.ts`.

This addresses the issue of the application not remembering its last window state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Window size and position are now automatically restored when reopening the app.
  - The app window will always open fully visible on your screen, even after display changes or moving between monitors.

- **Bug Fixes**
  - Resolved issues where the app window could appear off-screen or with incorrect sizing after display configuration changes.

- **Chores**
  - Updated license references to correct platform-specific package versions.
  - Upgraded the version of the vrchat-albums package with updated license information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->