### PR TITLE
refactor: VRChatログサービスを分割リファクタ

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,13 @@
       "Bash(mkdir:*)",
       "Bash(mv:*)",
       "Bash(yarn test:web:*)",
-      "Bash(yarn build)"
+      "Bash(yarn build)",
+      "Bash(yarn test:electron:*)",
+      "Bash(node:*)",
+      "Bash(yarn test:*)",
+      "Bash(npx tsc:*)",
+      "Bash(npx vitest run:*)",
+      "Bash(grep:*)"
     ],
     "deny": []
   }

--- a/electron/module/VRChatPlayerJoinLogModel/playerJoinInfoLog.model.ts
+++ b/electron/module/VRChatPlayerJoinLogModel/playerJoinInfoLog.model.ts
@@ -75,7 +75,11 @@ export const createVRChatPlayerJoinLog = async (
   const seen = new Set();
   const newLogsExcludeDup = playerJoinLogList
     .filter((logInfo) => {
-      const key = `${logInfo.joinDate.toISOString()}|${logInfo.playerName}`;
+      const key = `${logInfo.joinDate.toISOString()}|${
+        typeof logInfo.playerName === 'string'
+          ? logInfo.playerName
+          : logInfo.playerName.value
+      }`;
       if (existingSet.has(key) || seen.has(key)) {
         return false; // 既存セットまたは新しいセットに重複が見つかった場合は除外
       }
@@ -84,8 +88,14 @@ export const createVRChatPlayerJoinLog = async (
     })
     .map((logInfo) => ({
       joinDateTime: logInfo.joinDate,
-      playerId: logInfo.playerId,
-      playerName: logInfo.playerName,
+      playerId:
+        (typeof logInfo.playerId === 'string'
+          ? logInfo.playerId
+          : logInfo.playerId?.value) ?? null,
+      playerName:
+        typeof logInfo.playerName === 'string'
+          ? logInfo.playerName
+          : logInfo.playerName.value,
     }));
 
   if (newLogsExcludeDup.length < 1) {

--- a/electron/module/VRChatPlayerJoinLogModel/playerJoinLog.service.spec.ts
+++ b/electron/module/VRChatPlayerJoinLogModel/playerJoinLog.service.spec.ts
@@ -2,6 +2,7 @@ import * as service from './playerJoinLog.service';
 
 import * as datefns from 'date-fns';
 import * as client from '../../lib/sequelize';
+import { VRChatPlayerNameSchema } from '../vrchatLog/model';
 
 describe('VRChatPlayerJoinLogModel', () => {
   describe('createVRChatPlayerJoinLogModel', () => {

--- a/electron/module/VRChatPlayerLeaveLogModel/playerLeaveLog.service.ts
+++ b/electron/module/VRChatPlayerLeaveLogModel/playerLeaveLog.service.ts
@@ -4,14 +4,20 @@ import { VRChatPlayerLeaveLogModel } from './playerLeaveLog.model';
 export const createVRChatPlayerLeaveLogModel = async (
   leaveLogList: Array<{
     leaveDate: Date;
-    playerName: string;
-    playerId: string | null;
+    playerName: string | { value: string };
+    playerId: string | null | { value: string };
   }>,
 ): Promise<VRChatPlayerLeaveLogModel[]> => {
   const newLogs = leaveLogList.map((logInfo) => ({
     leaveDateTime: logInfo.leaveDate,
-    playerName: logInfo.playerName,
-    playerId: logInfo.playerId,
+    playerName:
+      typeof logInfo.playerName === 'string'
+        ? logInfo.playerName
+        : logInfo.playerName.value,
+    playerId:
+      typeof logInfo.playerId === 'string'
+        ? logInfo.playerId
+        : logInfo.playerId?.value ?? null,
   }));
 
   if (newLogs.length > 0) {

--- a/electron/module/logInfo/service.ts
+++ b/electron/module/logInfo/service.ts
@@ -315,7 +315,11 @@ export async function loadLogInfoIndexFromVRChatLog({
         worldJoinLogService.createVRChatWorldJoinLogModel(worldJoinLogBatch),
         playerJoinLogService.createVRChatPlayerJoinLogModel(playerJoinLogBatch),
         playerLeaveLogService.createVRChatPlayerLeaveLogModel(
-          playerLeaveLogBatch,
+          playerLeaveLogBatch.map((logInfo) => ({
+            leaveDate: logInfo.leaveDate,
+            playerName: logInfo.playerName.value,
+            playerId: logInfo.playerId?.value ?? null,
+          })),
         ),
       ]);
     const dbInsertEndTime = performance.now();

--- a/electron/module/vrchatLog/fileHandlers/index.ts
+++ b/electron/module/vrchatLog/fileHandlers/index.ts
@@ -1,0 +1,22 @@
+/**
+ * VRChatログのファイル操作機能をまとめたモジュール
+ */
+
+// ログファイル読み込み
+export {
+  getLogLinesFromLogFile,
+  getLogLinesByLogFilePathList,
+} from './logFileReader';
+
+// ログストレージ管理
+export {
+  getLogStoreDir,
+  initLogStoreDir,
+  getLogStoreFilePathForDate,
+  getLegacyLogStoreFilePath,
+  getLogStoreFilePathsInRange,
+  appendLoglinesToFile,
+} from './logStorageManager';
+
+// 写真からのログインポート
+export { importLogLinesFromLogPhotoDirPath } from './photoLogImporter';

--- a/electron/module/vrchatLog/fileHandlers/logFileReader.ts
+++ b/electron/module/vrchatLog/fileHandlers/logFileReader.ts
@@ -1,0 +1,89 @@
+import * as nodeFs from 'node:fs';
+import readline from 'node:readline';
+import * as neverthrow from 'neverthrow';
+import * as fs from '../../../lib/wrappedFs';
+import type { VRChatLogFilePath } from '../../vrchatLogFileDir/model';
+import type { VRChatLogFileError } from '../error';
+import type { VRChatLogLine, VRChatLogStoreFilePath } from '../model';
+import { VRChatLogLineSchema } from '../model';
+
+/**
+ * VRChatログファイルの読み込み機能
+ */
+
+/**
+ * ログファイルから指定された文字列を含む行を抽出
+ * @param props.logFilePath ログファイルのパス
+ * @param props.includesList 抽出対象とする文字列のリスト
+ * @returns 抽出されたログ行の配列
+ */
+export const getLogLinesFromLogFile = async (props: {
+  logFilePath: VRChatLogFilePath | VRChatLogStoreFilePath;
+  includesList: string[];
+}): Promise<neverthrow.Result<string[], VRChatLogFileError>> => {
+  // ファイルが存在するか確認
+  if (!nodeFs.existsSync(props.logFilePath.value)) {
+    // ファイルが存在しない場合は空の配列を返す
+    return neverthrow.ok([]);
+  }
+
+  const stream = fs.createReadStream(props.logFilePath.value);
+  const reader = readline.createInterface({
+    input: stream,
+    crlfDelay: Number.POSITIVE_INFINITY,
+  });
+
+  const lines: string[] = [];
+  reader.on('line', (line) => {
+    // includesList の配列の中のどれかと一致したら追加
+    if (props.includesList.some((include) => line.includes(include))) {
+      lines.push(line);
+    }
+  });
+
+  await Promise.all([
+    new Promise((resolve) => {
+      stream.on('close', () => {
+        resolve(null);
+      });
+    }),
+  ]);
+
+  return neverthrow.ok(lines);
+};
+
+/**
+ * 複数のログファイルから指定された文字列を含む行を抽出
+ * @param props.logFilePathList ログファイルパスのリスト
+ * @param props.includesList 抽出対象とする文字列のリスト
+ * @returns 抽出されたVRChatLogLineの配列
+ */
+export const getLogLinesByLogFilePathList = async (props: {
+  logFilePathList: (VRChatLogFilePath | VRChatLogStoreFilePath)[];
+  includesList: string[];
+}): Promise<neverthrow.Result<VRChatLogLine[], VRChatLogFileError>> => {
+  const logLineList: VRChatLogLine[] = [];
+  const errors: VRChatLogFileError[] = [];
+
+  await Promise.all(
+    props.logFilePathList.map(async (logFilePath) => {
+      const result = await getLogLinesFromLogFile({
+        logFilePath,
+        includesList: props.includesList,
+      });
+      if (result.isErr()) {
+        errors.push(result.error);
+        return;
+      }
+      logLineList.push(
+        ...result.value.map((line) => VRChatLogLineSchema.parse(line)),
+      );
+    }),
+  );
+
+  if (errors.length > 0) {
+    return neverthrow.err(errors[0]);
+  }
+
+  return neverthrow.ok(logLineList);
+};

--- a/electron/module/vrchatLog/fileHandlers/logStorageManager.ts
+++ b/electron/module/vrchatLog/fileHandlers/logStorageManager.ts
@@ -1,0 +1,221 @@
+import * as nodeFs from 'node:fs';
+import path from 'node:path';
+import * as datefns from 'date-fns';
+import * as neverthrow from 'neverthrow';
+import { getAppUserDataPath } from '../../../lib/wrappedApp';
+import * as fs from '../../../lib/wrappedFs';
+import type { VRChatLogLine, VRChatLogStoreFilePath } from '../model';
+import {
+  VRChatLogStoreFilePathRegex,
+  VRChatLogStoreFilePathSchema,
+  createTimestampedLogFilePath,
+} from '../model';
+
+/**
+ * VRChatログストレージの管理機能
+ * ログファイルの保存・読み込み・整理を担当
+ */
+
+/**
+ * logStoreディレクトリのパスを取得
+ * logStoreディレクトリは、VRChatログから抽出した必要な情報のみを保存するディレクトリ
+ */
+export const getLogStoreDir = (): string => {
+  return path.join(getAppUserDataPath(), 'logStore');
+};
+
+/**
+ * logStoreディレクトリを初期化
+ * ディレクトリが存在しない場合は作成する
+ */
+export const initLogStoreDir = (): void => {
+  const logStoreDir = getLogStoreDir();
+  if (!nodeFs.existsSync(logStoreDir)) {
+    nodeFs.mkdirSync(logStoreDir, { recursive: true });
+  }
+};
+
+/**
+ * 指定された日付に基づいてログストアファイルのパスを生成
+ * @param date 対象日付（デフォルトは現在日付）
+ * @returns ログストアファイルのパス
+ */
+export const getLogStoreFilePathForDate = (
+  date: Date = new Date(),
+): VRChatLogStoreFilePath => {
+  const yearMonth = datefns.format(date, 'yyyy-MM');
+  const logStoreFilePath = path.join(
+    getLogStoreDir(),
+    yearMonth,
+    `logStore-${yearMonth}.txt`,
+  );
+  return VRChatLogStoreFilePathSchema.parse(logStoreFilePath);
+};
+
+/**
+ * 旧形式のログファイルパスを取得
+ * @returns 旧形式のログファイルパス、存在しない場合はnull
+ */
+export const getLegacyLogStoreFilePath =
+  async (): Promise<VRChatLogStoreFilePath | null> => {
+    const legacyPath = path.join(getLogStoreDir(), 'logStore.txt');
+    if (!nodeFs.existsSync(legacyPath)) {
+      return null;
+    }
+    return VRChatLogStoreFilePathSchema.parse(legacyPath);
+  };
+
+/**
+ * 指定された日付範囲のログストアファイルのパスを取得
+ * @param startDate 開始日付
+ * @param currentDate 終了日付
+ * @returns ログストアファイルパスの配列
+ */
+export const getLogStoreFilePathsInRange = async (
+  startDate: Date,
+  currentDate: Date,
+): Promise<VRChatLogStoreFilePath[]> => {
+  const logFilePathSet = new Set<string>();
+  let targetDate = datefns.startOfMonth(startDate);
+  const endDate = datefns.endOfMonth(currentDate);
+
+  while (
+    datefns.isBefore(targetDate, endDate) ||
+    datefns.isSameDay(targetDate, endDate)
+  ) {
+    const yearMonth = datefns.format(targetDate, 'yyyy-MM');
+    const monthDir = path.join(getLogStoreDir(), yearMonth);
+    const standardLogFilePath = getLogStoreFilePathForDate(targetDate);
+
+    logFilePathSet.add(standardLogFilePath.value);
+
+    // 同じ月のタイムスタンプ付きのログファイルを検索
+    if (nodeFs.existsSync(monthDir)) {
+      try {
+        const files = nodeFs.readdirSync(monthDir);
+        const timestampedLogFiles = files.filter((file) =>
+          file.match(VRChatLogStoreFilePathRegex),
+        );
+
+        for (const file of timestampedLogFiles) {
+          const fullPath = path.join(monthDir, file);
+          logFilePathSet.add(fullPath);
+        }
+      } catch (err) {
+        console.error(`Error reading directory ${monthDir}:`, err);
+      }
+    }
+
+    targetDate = datefns.addMonths(targetDate, 1);
+  }
+
+  return Array.from(logFilePathSet).map((p) =>
+    VRChatLogStoreFilePathSchema.parse(p),
+  );
+};
+
+/**
+ * ログ行をストレージファイルに追記
+ * @param props.logLines 追記するログ行
+ * @param props.logStoreFilePath 保存先ファイルパス（省略時は日付から自動決定）
+ * @returns 成功時はok、失敗時はerr
+ */
+export const appendLoglinesToFile = async (props: {
+  logLines: VRChatLogLine[];
+  logStoreFilePath?: VRChatLogStoreFilePath;
+}): Promise<neverthrow.Result<void, never>> => {
+  if (props.logLines.length === 0) {
+    return neverthrow.ok(undefined);
+  }
+
+  // ログを日付ごとにグループ化
+  const logsByMonth = new Map<string, VRChatLogLine[]>();
+
+  for (const logLine of props.logLines) {
+    const dateMatch = logLine.value.match(/^(\d{4})\.(\d{2})\.(\d{2})/);
+    if (!dateMatch) {
+      const key = datefns.format(new Date(), 'yyyy-MM');
+      const monthLogs = logsByMonth.get(key) || [];
+      monthLogs.push(logLine);
+      logsByMonth.set(key, monthLogs);
+      continue;
+    }
+
+    const year = dateMatch[1];
+    const month = dateMatch[2];
+    const key = `${year}-${month}`;
+
+    const monthLogs = logsByMonth.get(key) || [];
+    monthLogs.push(logLine);
+    logsByMonth.set(key, monthLogs);
+  }
+
+  // 各月のログを対応するファイルに書き込む
+  for (const [yearMonth, logs] of logsByMonth.entries()) {
+    const [year, month] = yearMonth.split('-');
+    const date = datefns.parse(`${year}-${month}-01`, 'yyyy-MM-dd', new Date());
+
+    const monthDir = path.join(getLogStoreDir(), yearMonth);
+
+    initLogStoreDir();
+
+    if (!nodeFs.existsSync(monthDir)) {
+      nodeFs.mkdirSync(monthDir, { recursive: true });
+    }
+
+    const logStoreFilePath = getLogStoreFilePathForDate(date);
+    const isExists = await fs.existsSyncSafe(logStoreFilePath.value);
+
+    // ファイルサイズをチェック（10MB制限）
+    if (isExists) {
+      const stats = nodeFs.statSync(logStoreFilePath.value);
+      if (stats.size >= 10 * 1024 * 1024) {
+        const timestamp = new Date();
+        const newFilePath = createTimestampedLogFilePath(
+          monthDir,
+          yearMonth,
+          timestamp,
+        );
+
+        const newLog = `${logs.map((l) => l.value).join('\n')}\n`;
+        const writeResult = await fs.writeFileSyncSafe(newFilePath, newLog);
+        if (writeResult.isErr()) {
+          throw writeResult.error;
+        }
+        continue;
+      }
+    }
+
+    // 既存のログ行をSetとして保持
+    const existingLines = new Set<string>();
+
+    if (isExists) {
+      const readResult = await fs.readFileSyncSafe(logStoreFilePath.value);
+      if (readResult.isOk()) {
+        const content = readResult.value.toString();
+        for (const line of content.split('\n')) {
+          if (line) {
+            existingLines.add(line);
+          }
+        }
+      }
+    }
+
+    // 重複を除外して新しいログ行を追加
+    const newLines = logs.filter((log) => !existingLines.has(log.value));
+    if (newLines.length === 0) {
+      continue;
+    }
+
+    const newLog = `${newLines.map((l) => l.value).join('\n')}\n`;
+    const writeResult = await fs.writeFileSyncSafe(
+      logStoreFilePath.value,
+      newLog,
+    );
+    if (writeResult.isErr()) {
+      throw writeResult.error;
+    }
+  }
+
+  return neverthrow.ok(undefined);
+};

--- a/electron/module/vrchatLog/fileHandlers/photoLogImporter.ts
+++ b/electron/module/vrchatLog/fileHandlers/photoLogImporter.ts
@@ -1,0 +1,75 @@
+import path from 'node:path';
+import * as datefns from 'date-fns';
+import { glob } from 'glob';
+import type { VRChatPhotoDirPath } from '../../vrchatPhoto/valueObjects';
+import { createVRChatWorldJoinLogFromPhoto } from '../../vrchatWorldJoinLogFromPhoto/service';
+import type { VRChatWorldJoinLogFromPhoto } from '../../vrchatWorldJoinLogFromPhoto/vrchatWorldJoinLogFromPhoto.model';
+
+type WorldId = `wrld_${string}`;
+
+/**
+ * 写真ファイル名からログ情報をインポートする機能
+ * 旧アプリで生成された写真ファイル名にはワールドIDと参加日時が含まれている
+ */
+
+/**
+ * 写真ディレクトリからワールド参加ログを抽出
+ * @param vrChatPhotoDirPath VRChat写真ディレクトリのパス
+ * @returns ワールド参加ログの配列
+ */
+const getLogLinesFromLogPhotoDirPath = async ({
+  vrChatPhotoDirPath,
+}: { vrChatPhotoDirPath: VRChatPhotoDirPath }): Promise<
+  VRChatWorldJoinLogFromPhoto[]
+> => {
+  const globPath = path.posix.join(
+    vrChatPhotoDirPath.value,
+    '**',
+    'VRChat_*_wrld_*',
+  );
+  // 正規表現にマッチするファイルを再帰的に取得
+  const logPhotoFilePathList = await glob(globPath);
+
+  // ファイル名のパターン:
+  // VRChat_YYYY-MM-DD_HH-mm-ss.SSS_wrld_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.ext
+  const worldJoinLogList = logPhotoFilePathList
+    .map((filePath) => {
+      const regex =
+        /VRChat_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.\d{3})_wrld_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.[a-z]+/;
+      const matches = filePath.match(regex);
+      if (!matches) {
+        return null;
+      }
+      return {
+        // ファイル名の日時はlocal timeなので、そのままパース
+        joinDate: datefns.parse(
+          matches[1],
+          'yyyy-MM-dd_HH-mm-ss.SSS',
+          new Date(),
+        ),
+        worldId: `wrld_${matches[2]}` as WorldId,
+      };
+    })
+    .filter((log) => log !== null);
+
+  return worldJoinLogList;
+};
+
+/**
+ * 写真として保存されているワールドへのJoinログをデータベースに保存
+ * @param vrChatPhotoDirPath VRChat写真ディレクトリのパス
+ */
+export const importLogLinesFromLogPhotoDirPath = async ({
+  vrChatPhotoDirPath,
+}: { vrChatPhotoDirPath: VRChatPhotoDirPath }): Promise<void> => {
+  const logLines = await getLogLinesFromLogPhotoDirPath({
+    vrChatPhotoDirPath,
+  });
+
+  const worldJoinLogs: VRChatWorldJoinLogFromPhoto[] = logLines.map((log) => ({
+    joinDate: log.joinDate,
+    worldId: log.worldId,
+  }));
+
+  await createVRChatWorldJoinLogFromPhoto(worldJoinLogs);
+};

--- a/electron/module/vrchatLog/model.test.ts
+++ b/electron/module/vrchatLog/model.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import {
+  OptionalVRChatPlayerIdSchema,
+  VRChatPlayerId,
+  VRChatPlayerIdSchema,
+  VRChatPlayerName,
+  VRChatPlayerNameSchema,
+  VRChatWorldId,
+  VRChatWorldIdSchema,
+  VRChatWorldInstanceId,
+  VRChatWorldInstanceIdSchema,
+  VRChatWorldName,
+  VRChatWorldNameSchema,
+} from './model';
+
+describe('VRChatログ関連のvalueObjects', () => {
+  describe('VRChatPlayerId', () => {
+    it('有効なプレイヤーIDでvalueObjectを作成できる', () => {
+      const validId = 'usr_12345678-1234-1234-1234-123456789abc';
+      const playerId = VRChatPlayerIdSchema.parse(validId);
+      expect(playerId.value).toBe(validId);
+    });
+
+    it('無効なプレイヤーIDでエラーが発生する', () => {
+      expect(() => VRChatPlayerIdSchema.parse('invalid-id')).toThrow();
+      expect(() =>
+        VRChatPlayerIdSchema.parse('user_12345678-1234-1234-1234-123456789abc'),
+      ).toThrow();
+      expect(() => VRChatPlayerIdSchema.parse('')).toThrow();
+    });
+
+    it('isValid静的メソッドが正しく動作する', () => {
+      expect(
+        VRChatPlayerId.isValid('usr_12345678-1234-1234-1234-123456789abc'),
+      ).toBe(true);
+      expect(VRChatPlayerId.isValid('invalid-id')).toBe(false);
+    });
+  });
+
+  describe('VRChatWorldId', () => {
+    it('有効なワールドIDでvalueObjectを作成できる', () => {
+      const validId = 'wrld_12345678-1234-1234-1234-123456789abc';
+      const worldId = VRChatWorldIdSchema.parse(validId);
+      expect(worldId.value).toBe(validId);
+    });
+
+    it('無効なワールドIDでエラーが発生する', () => {
+      expect(() => VRChatWorldIdSchema.parse('invalid-id')).toThrow();
+      expect(() =>
+        VRChatWorldIdSchema.parse('world_12345678-1234-1234-1234-123456789abc'),
+      ).toThrow();
+      expect(() => VRChatWorldIdSchema.parse('')).toThrow();
+    });
+
+    it('isValid静的メソッドが正しく動作する', () => {
+      expect(
+        VRChatWorldId.isValid('wrld_12345678-1234-1234-1234-123456789abc'),
+      ).toBe(true);
+      expect(VRChatWorldId.isValid('invalid-id')).toBe(false);
+    });
+  });
+
+  describe('VRChatWorldInstanceId', () => {
+    it('有効なインスタンスIDでvalueObjectを作成できる', () => {
+      const validId = '12345';
+      const instanceId = VRChatWorldInstanceIdSchema.parse(validId);
+      expect(instanceId.value).toBe(validId);
+    });
+
+    it('region情報付きのインスタンスIDでvalueObjectを作成できる', () => {
+      const validId = '86676~region(jp)';
+      const instanceId = VRChatWorldInstanceIdSchema.parse(validId);
+      expect(instanceId.value).toBe(validId);
+    });
+
+    it('無効なインスタンスIDでエラーが発生する', () => {
+      expect(() => VRChatWorldInstanceIdSchema.parse('invalid-id')).toThrow();
+      expect(() => VRChatWorldInstanceIdSchema.parse('12345a')).toThrow();
+      expect(() => VRChatWorldInstanceIdSchema.parse('')).toThrow();
+    });
+
+    it('isValid静的メソッドが正しく動作する', () => {
+      expect(VRChatWorldInstanceId.isValid('12345')).toBe(true);
+      expect(VRChatWorldInstanceId.isValid('86676~region(jp)')).toBe(true);
+      expect(VRChatWorldInstanceId.isValid('invalid-id')).toBe(false);
+    });
+  });
+
+  describe('VRChatPlayerName', () => {
+    it('有効なプレイヤー名でvalueObjectを作成できる', () => {
+      const validName = 'TestPlayer';
+      const playerName = VRChatPlayerNameSchema.parse(validName);
+      expect(playerName.value).toBe(validName);
+    });
+
+    it('スペースを含むプレイヤー名でも作成できる', () => {
+      const validName = 'Test Player With Spaces';
+      const playerName = VRChatPlayerNameSchema.parse(validName);
+      expect(playerName.value).toBe(validName);
+    });
+
+    it('空文字列や空白のみでエラーが発生する', () => {
+      expect(() => VRChatPlayerNameSchema.parse('')).toThrow();
+      expect(() => VRChatPlayerNameSchema.parse('   ')).toThrow();
+    });
+
+    it('isValid静的メソッドが正しく動作する', () => {
+      expect(VRChatPlayerName.isValid('TestPlayer')).toBe(true);
+      expect(VRChatPlayerName.isValid('Test Player With Spaces')).toBe(true);
+      expect(VRChatPlayerName.isValid('')).toBe(false);
+      expect(VRChatPlayerName.isValid('   ')).toBe(false);
+    });
+  });
+
+  describe('VRChatWorldName', () => {
+    it('有効なワールド名でvalueObjectを作成できる', () => {
+      const validName = 'Test World';
+      const worldName = VRChatWorldNameSchema.parse(validName);
+      expect(worldName.value).toBe(validName);
+    });
+
+    it('空文字列や空白のみでエラーが発生する', () => {
+      expect(() => VRChatWorldNameSchema.parse('')).toThrow();
+      expect(() => VRChatWorldNameSchema.parse('   ')).toThrow();
+    });
+
+    it('isValid静的メソッドが正しく動作する', () => {
+      expect(VRChatWorldName.isValid('Test World')).toBe(true);
+      expect(VRChatWorldName.isValid('')).toBe(false);
+      expect(VRChatWorldName.isValid('   ')).toBe(false);
+    });
+  });
+
+  describe('OptionalVRChatPlayerId', () => {
+    it('nullの場合はnullを返す', () => {
+      const result = OptionalVRChatPlayerIdSchema.parse(null);
+      expect(result).toBeNull();
+    });
+
+    it('有効なIDの場合はvalueObjectを返す', () => {
+      const validId = 'usr_12345678-1234-1234-1234-123456789abc';
+      const result = OptionalVRChatPlayerIdSchema.parse(validId);
+      expect(result?.value).toBe(validId);
+    });
+
+    it('無効なIDの場合はエラーが発生する', () => {
+      expect(() => OptionalVRChatPlayerIdSchema.parse('invalid-id')).toThrow();
+    });
+  });
+});

--- a/electron/module/vrchatLog/parsers/baseParser.test.ts
+++ b/electron/module/vrchatLog/parsers/baseParser.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { VRChatLogLineSchema } from '../model';
+import {
+  filterLogLinesByDate,
+  isValidPlayerId,
+  isValidWorldId,
+  parseLogDateTime,
+} from './baseParser';
+
+describe('baseParser', () => {
+  describe('parseLogDateTime', () => {
+    it('正しい日付時刻文字列をパースできる', () => {
+      const result = parseLogDateTime('2023.10.08', '15:30:45');
+      expect(result).toEqual(new Date('2023-10-08T15:30:45'));
+    });
+  });
+
+  describe('isValidWorldId', () => {
+    it('有効なワールドIDを正しく判定する', () => {
+      expect(isValidWorldId('wrld_12345678-1234-1234-1234-123456789abc')).toBe(
+        true,
+      );
+      expect(isValidWorldId('wrld_abcdef12-3456-7890-abcd-ef1234567890')).toBe(
+        true,
+      );
+    });
+
+    it('無効なワールドIDを正しく判定する', () => {
+      expect(isValidWorldId('invalid-world-id')).toBe(false);
+      expect(isValidWorldId('world_12345678-1234-1234-1234-123456789abc')).toBe(
+        false,
+      );
+      expect(isValidWorldId('wrld_invalid-format')).toBe(false);
+      expect(
+        isValidWorldId('wrld_12345678-1234-1234-1234-123456789abcdef'),
+      ).toBe(false); // too long
+      expect(isValidWorldId('')).toBe(false);
+    });
+  });
+
+  describe('isValidPlayerId', () => {
+    it('有効なプレイヤーIDを正しく判定する', () => {
+      expect(isValidPlayerId('usr_12345678-1234-1234-1234-123456789abc')).toBe(
+        true,
+      );
+      expect(isValidPlayerId('usr_abcdef12-3456-7890-abcd-ef1234567890')).toBe(
+        true,
+      );
+    });
+
+    it('無効なプレイヤーIDを正しく判定する', () => {
+      expect(isValidPlayerId('invalid-player-id')).toBe(false);
+      expect(isValidPlayerId('user_12345678-1234-1234-1234-123456789abc')).toBe(
+        false,
+      );
+      expect(isValidPlayerId('usr_invalid-format')).toBe(false);
+      expect(
+        isValidPlayerId('usr_12345678-1234-1234-1234-123456789abcdef'),
+      ).toBe(false); // too long
+      expect(isValidPlayerId('')).toBe(false);
+    });
+  });
+
+  describe('filterLogLinesByDate', () => {
+    it('指定日以降のログのみフィルタリングできる', () => {
+      const logLines = [
+        VRChatLogLineSchema.parse('2023.10.07 10:00:00 Log - Test log 1'),
+        VRChatLogLineSchema.parse('2023.10.08 15:30:00 Log - Test log 2'),
+        VRChatLogLineSchema.parse('2023.10.09 20:45:00 Log - Test log 3'),
+      ];
+
+      const startDate = new Date('2023-10-08T00:00:00');
+      const result = filterLogLinesByDate(logLines, startDate);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].value).toContain('2023.10.08');
+      expect(result[1].value).toContain('2023.10.09');
+    });
+
+    it('日付形式が不正なログを除外する', () => {
+      const logLines = [
+        VRChatLogLineSchema.parse('2023.10.08 15:30:00 Log - Valid log'),
+        VRChatLogLineSchema.parse('Invalid date format log'),
+      ];
+
+      const startDate = new Date('2023-10-08T00:00:00');
+      const result = filterLogLinesByDate(logLines, startDate);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].value).toContain('Valid log');
+    });
+  });
+});

--- a/electron/module/vrchatLog/parsers/baseParser.test.ts
+++ b/electron/module/vrchatLog/parsers/baseParser.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { VRChatLogLineSchema } from '../model';
-import {
-  filterLogLinesByDate,
-  isValidPlayerId,
-  isValidWorldId,
-  parseLogDateTime,
-} from './baseParser';
+import { VRChatLogLineSchema, VRChatPlayerId, VRChatWorldId } from '../model';
+import { filterLogLinesByDate, parseLogDateTime } from './baseParser';
 
 describe('baseParser', () => {
   describe('parseLogDateTime', () => {
@@ -15,49 +10,49 @@ describe('baseParser', () => {
     });
   });
 
-  describe('isValidWorldId', () => {
+  describe('VRChatWorldId.isValid', () => {
     it('有効なワールドIDを正しく判定する', () => {
-      expect(isValidWorldId('wrld_12345678-1234-1234-1234-123456789abc')).toBe(
-        true,
-      );
-      expect(isValidWorldId('wrld_abcdef12-3456-7890-abcd-ef1234567890')).toBe(
-        true,
-      );
+      expect(
+        VRChatWorldId.isValid('wrld_12345678-1234-1234-1234-123456789abc'),
+      ).toBe(true);
+      expect(
+        VRChatWorldId.isValid('wrld_abcdef12-3456-7890-abcd-ef1234567890'),
+      ).toBe(true);
     });
 
     it('無効なワールドIDを正しく判定する', () => {
-      expect(isValidWorldId('invalid-world-id')).toBe(false);
-      expect(isValidWorldId('world_12345678-1234-1234-1234-123456789abc')).toBe(
-        false,
-      );
-      expect(isValidWorldId('wrld_invalid-format')).toBe(false);
+      expect(VRChatWorldId.isValid('invalid-world-id')).toBe(false);
       expect(
-        isValidWorldId('wrld_12345678-1234-1234-1234-123456789abcdef'),
+        VRChatWorldId.isValid('world_12345678-1234-1234-1234-123456789abc'),
+      ).toBe(false);
+      expect(VRChatWorldId.isValid('wrld_invalid-format')).toBe(false);
+      expect(
+        VRChatWorldId.isValid('wrld_12345678-1234-1234-1234-123456789abcdef'),
       ).toBe(false); // too long
-      expect(isValidWorldId('')).toBe(false);
+      expect(VRChatWorldId.isValid('')).toBe(false);
     });
   });
 
-  describe('isValidPlayerId', () => {
+  describe('VRChatPlayerId.isValid', () => {
     it('有効なプレイヤーIDを正しく判定する', () => {
-      expect(isValidPlayerId('usr_12345678-1234-1234-1234-123456789abc')).toBe(
-        true,
-      );
-      expect(isValidPlayerId('usr_abcdef12-3456-7890-abcd-ef1234567890')).toBe(
-        true,
-      );
+      expect(
+        VRChatPlayerId.isValid('usr_12345678-1234-1234-1234-123456789abc'),
+      ).toBe(true);
+      expect(
+        VRChatPlayerId.isValid('usr_abcdef12-3456-7890-abcd-ef1234567890'),
+      ).toBe(true);
     });
 
     it('無効なプレイヤーIDを正しく判定する', () => {
-      expect(isValidPlayerId('invalid-player-id')).toBe(false);
-      expect(isValidPlayerId('user_12345678-1234-1234-1234-123456789abc')).toBe(
-        false,
-      );
-      expect(isValidPlayerId('usr_invalid-format')).toBe(false);
+      expect(VRChatPlayerId.isValid('invalid-player-id')).toBe(false);
       expect(
-        isValidPlayerId('usr_12345678-1234-1234-1234-123456789abcdef'),
+        VRChatPlayerId.isValid('user_12345678-1234-1234-1234-123456789abc'),
+      ).toBe(false);
+      expect(VRChatPlayerId.isValid('usr_invalid-format')).toBe(false);
+      expect(
+        VRChatPlayerId.isValid('usr_12345678-1234-1234-1234-123456789abcdef'),
       ).toBe(false); // too long
-      expect(isValidPlayerId('')).toBe(false);
+      expect(VRChatPlayerId.isValid('')).toBe(false);
     });
   });
 

--- a/electron/module/vrchatLog/parsers/baseParser.ts
+++ b/electron/module/vrchatLog/parsers/baseParser.ts
@@ -1,0 +1,82 @@
+import * as datefns from 'date-fns';
+import type { VRChatLogLine } from '../model';
+
+/**
+ * VRChatログの基本的なパース機能を提供
+ */
+
+/**
+ * ログ行から日付と時刻を抽出してDateオブジェクトに変換
+ * @param dateStr YYYY.MM.DD形式の日付文字列
+ * @param timeStr HH:mm:ss形式の時刻文字列
+ * @returns パースされたDateオブジェクト
+ */
+export const parseLogDateTime = (dateStr: string, timeStr: string): Date => {
+  const formattedDate = dateStr.replace(/\./g, '-');
+  return datefns.parse(
+    `${formattedDate} ${timeStr}`,
+    'yyyy-MM-dd HH:mm:ss',
+    new Date(),
+  );
+};
+
+/**
+ * ログ行の基本的な正規表現パターン
+ */
+export const LOG_DATE_TIME_PATTERN =
+  /(\d{4}\.\d{2}\.\d{2}) (\d{2}:\d{2}:\d{2})/;
+
+/**
+ * ワールドIDの検証
+ * @param value 検証する文字列
+ * @returns ワールドIDとして有効な場合true
+ */
+export const isValidWorldId = (value: string): boolean => {
+  const regex =
+    /^wrld_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+  return regex.test(value);
+};
+
+/**
+ * プレイヤーIDの検証
+ * @param value 検証する文字列
+ * @returns プレイヤーIDとして有効な場合true
+ */
+export const isValidPlayerId = (value: string): boolean => {
+  const regex =
+    /^usr_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+  return regex.test(value);
+};
+
+/**
+ * ログ行を日付でフィルタリング
+ * @param logLines フィルタリング対象のログ行
+ * @param startDate この日付以降のログを含む
+ * @returns フィルタリングされたログ行
+ */
+export const filterLogLinesByDate = (
+  logLines: VRChatLogLine[],
+  startDate: Date,
+): VRChatLogLine[] => {
+  return logLines.filter((logLine) => {
+    const dateTimeMatch = logLine.value.match(
+      /^(\d{4})\.(\d{2})\.(\d{2}) (\d{2}):(\d{2}):(\d{2})/,
+    );
+    if (!dateTimeMatch) return false;
+
+    const [, year, month, day, hour, minute, second] = dateTimeMatch;
+    const logDate = datefns.parse(
+      `${year}-${month}-${day} ${hour}:${minute}:${second}`,
+      'yyyy-MM-dd HH:mm:ss',
+      new Date(),
+    );
+
+    if (!datefns.isValid(logDate)) {
+      return false;
+    }
+
+    return (
+      datefns.isAfter(logDate, startDate) || datefns.isEqual(logDate, startDate)
+    );
+  });
+};

--- a/electron/module/vrchatLog/parsers/baseParser.ts
+++ b/electron/module/vrchatLog/parsers/baseParser.ts
@@ -26,27 +26,11 @@ export const parseLogDateTime = (dateStr: string, timeStr: string): Date => {
 export const LOG_DATE_TIME_PATTERN =
   /(\d{4}\.\d{2}\.\d{2}) (\d{2}:\d{2}:\d{2})/;
 
-/**
- * ワールドIDの検証
- * @param value 検証する文字列
- * @returns ワールドIDとして有効な場合true
- */
-export const isValidWorldId = (value: string): boolean => {
-  const regex =
-    /^wrld_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-  return regex.test(value);
-};
+// 注意: ワールドID検証機能はvalueObjectsパターンに移行されました
+// VRChatWorldId.isValid() を使用してください
 
-/**
- * プレイヤーIDの検証
- * @param value 検証する文字列
- * @returns プレイヤーIDとして有効な場合true
- */
-export const isValidPlayerId = (value: string): boolean => {
-  const regex =
-    /^usr_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-  return regex.test(value);
-};
+// 注意: プレイヤーID検証機能はvalueObjectsパターンに移行されました
+// VRChatPlayerId.isValid() を使用してください
 
 /**
  * ログ行を日付でフィルタリング

--- a/electron/module/vrchatLog/parsers/index.ts
+++ b/electron/module/vrchatLog/parsers/index.ts
@@ -1,0 +1,76 @@
+import type { VRChatLogLine } from '../model';
+import {
+  type VRChatPlayerJoinLog,
+  type VRChatPlayerLeaveLog,
+  extractPlayerJoinInfoFromLog,
+  extractPlayerLeaveInfoFromLog,
+} from './playerActionParser';
+import {
+  type VRChatWorldJoinLog,
+  extractWorldJoinInfoFromLogs,
+} from './worldJoinParser';
+
+/**
+ * VRChatログのパース機能をまとめたモジュール
+ */
+
+/**
+ * ログ行の配列をワールド参加・プレイヤー参加/退出情報に変換
+ * @param logLines パース対象のログ行
+ * @returns 抽出されたログ情報の配列
+ */
+export const convertLogLinesToWorldAndPlayerJoinLogInfos = (
+  logLines: VRChatLogLine[],
+): (VRChatWorldJoinLog | VRChatPlayerJoinLog | VRChatPlayerLeaveLog)[] => {
+  const logInfos: (
+    | VRChatWorldJoinLog
+    | VRChatPlayerJoinLog
+    | VRChatPlayerLeaveLog
+  )[] = [];
+
+  for (const [index, l] of logLines.entries()) {
+    // ワールド参加ログ
+    if (l.value.includes('Joining wrld')) {
+      const info = extractWorldJoinInfoFromLogs(logLines, index);
+      if (info) {
+        logInfos.push(info);
+      }
+    }
+
+    // プレイヤー参加ログ
+    if (l.value.includes('[Behaviour] OnPlayerJoined')) {
+      const info = extractPlayerJoinInfoFromLog(l);
+      if (info) {
+        logInfos.push(info);
+      }
+    }
+
+    // プレイヤー退出ログ（OnPlayerLeftRoomは除外）
+    if (
+      l.value.includes('OnPlayerLeft') &&
+      !l.value.includes('OnPlayerLeftRoom')
+    ) {
+      const info = extractPlayerLeaveInfoFromLog(l);
+      if (info) {
+        logInfos.push(info);
+      }
+    }
+  }
+
+  return logInfos;
+};
+
+// 型定義の再エクスポート
+export type { VRChatWorldJoinLog } from './worldJoinParser';
+export type {
+  VRChatPlayerJoinLog,
+  VRChatPlayerLeaveLog,
+} from './playerActionParser';
+
+// 個別のパーサー関数も再エクスポート
+export { extractWorldJoinInfoFromLogs } from './worldJoinParser';
+export {
+  extractPlayerJoinInfoFromLog,
+  extractPlayerLeaveInfoFromLog,
+} from './playerActionParser';
+export { filterLogLinesByDate } from './baseParser';

--- a/electron/module/vrchatLog/parsers/playerActionParser.test.ts
+++ b/electron/module/vrchatLog/parsers/playerActionParser.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { VRChatLogLineSchema } from '../model';
+import {
+  extractPlayerJoinInfoFromLog,
+  extractPlayerLeaveInfoFromLog,
+} from './playerActionParser';
+
+describe('playerActionParser', () => {
+  describe('extractPlayerJoinInfoFromLog', () => {
+    it('プレイヤー参加ログから正しい情報を抽出できる', () => {
+      const logLine = VRChatLogLineSchema.parse(
+        '2025.01.07 23:25:34 Log        -  [Behaviour] OnPlayerJoined TestPlayer (usr_12345678-1234-1234-1234-123456789abc)',
+      );
+
+      const result = extractPlayerJoinInfoFromLog(logLine);
+
+      expect(result.logType).toBe('playerJoin');
+      expect(result.playerName).toBe('TestPlayer');
+      expect(result.playerId).toBe('usr_12345678-1234-1234-1234-123456789abc');
+      expect(result.joinDate).toEqual(new Date('2025-01-07T23:25:34'));
+    });
+
+    it('プレイヤーIDがないプレイヤー参加ログを処理できる', () => {
+      const logLine = VRChatLogLineSchema.parse(
+        '2025.01.07 23:25:34 Log        -  [Behaviour] OnPlayerJoined TestPlayer',
+      );
+
+      const result = extractPlayerJoinInfoFromLog(logLine);
+
+      expect(result.logType).toBe('playerJoin');
+      expect(result.playerName).toBe('TestPlayer');
+      expect(result.playerId).toBeNull();
+      expect(result.joinDate).toEqual(new Date('2025-01-07T23:25:34'));
+    });
+
+    it('空白を含むプレイヤー名を正しく処理できる', () => {
+      const logLine = VRChatLogLineSchema.parse(
+        '2025.01.07 23:25:34 Log        -  [Behaviour] OnPlayerJoined Test Player Name (usr_12345678-1234-1234-1234-123456789abc)',
+      );
+
+      const result = extractPlayerJoinInfoFromLog(logLine);
+      expect(result.playerName).toBe('Test Player Name');
+    });
+
+    it('無効な形式の場合はエラーを投げる', () => {
+      const logLine = VRChatLogLineSchema.parse('Invalid log format');
+
+      expect(() => extractPlayerJoinInfoFromLog(logLine)).toThrow(
+        'Log line did not match the expected format',
+      );
+    });
+  });
+
+  describe('extractPlayerLeaveInfoFromLog', () => {
+    it('プレイヤー退出ログから正しい情報を抽出できる', () => {
+      const logLine = VRChatLogLineSchema.parse(
+        '2025.01.08 00:22:04 Log        -  [Behaviour] OnPlayerLeft TestPlayer (usr_12345678-1234-1234-1234-123456789abc)',
+      );
+
+      const result = extractPlayerLeaveInfoFromLog(logLine);
+
+      expect(result.logType).toBe('playerLeave');
+      expect(result.playerName).toBe('TestPlayer');
+      expect(result.playerId).toBe('usr_12345678-1234-1234-1234-123456789abc');
+      expect(result.leaveDate).toEqual(new Date('2025-01-08T00:22:04'));
+    });
+
+    it('特殊文字を含むプレイヤー名を正しく処理できる', () => {
+      const logLine = VRChatLogLineSchema.parse(
+        '2025.01.08 00:22:04 Log        -  [Behaviour] OnPlayerLeft プレイヤー ⁄ A (usr_12345678-1234-1234-1234-123456789abc)',
+      );
+
+      const result = extractPlayerLeaveInfoFromLog(logLine);
+      expect(result.playerName).toBe('プレイヤー ⁄ A');
+    });
+
+    it('プレイヤーIDがない退出ログを処理できる', () => {
+      const logLine = VRChatLogLineSchema.parse(
+        '2025.01.08 00:22:04 Debug      -  [Behaviour] OnPlayerLeft TestPlayer',
+      );
+
+      const result = extractPlayerLeaveInfoFromLog(logLine);
+      expect(result.playerName).toBe('TestPlayer');
+      expect(result.playerId).toBeNull();
+    });
+
+    it('無効な形式の場合はエラーを投げる', () => {
+      const logLine = VRChatLogLineSchema.parse('Invalid log format');
+
+      expect(() => extractPlayerLeaveInfoFromLog(logLine)).toThrow(
+        'Log line did not match the expected format',
+      );
+    });
+  });
+});

--- a/electron/module/vrchatLog/parsers/playerActionParser.test.ts
+++ b/electron/module/vrchatLog/parsers/playerActionParser.test.ts
@@ -15,8 +15,10 @@ describe('playerActionParser', () => {
       const result = extractPlayerJoinInfoFromLog(logLine);
 
       expect(result.logType).toBe('playerJoin');
-      expect(result.playerName).toBe('TestPlayer');
-      expect(result.playerId).toBe('usr_12345678-1234-1234-1234-123456789abc');
+      expect(result.playerName.value).toBe('TestPlayer');
+      expect(result.playerId?.value).toBe(
+        'usr_12345678-1234-1234-1234-123456789abc',
+      );
       expect(result.joinDate).toEqual(new Date('2025-01-07T23:25:34'));
     });
 
@@ -28,7 +30,7 @@ describe('playerActionParser', () => {
       const result = extractPlayerJoinInfoFromLog(logLine);
 
       expect(result.logType).toBe('playerJoin');
-      expect(result.playerName).toBe('TestPlayer');
+      expect(result.playerName.value).toBe('TestPlayer');
       expect(result.playerId).toBeNull();
       expect(result.joinDate).toEqual(new Date('2025-01-07T23:25:34'));
     });
@@ -39,7 +41,7 @@ describe('playerActionParser', () => {
       );
 
       const result = extractPlayerJoinInfoFromLog(logLine);
-      expect(result.playerName).toBe('Test Player Name');
+      expect(result.playerName.value).toBe('Test Player Name');
     });
 
     it('無効な形式の場合はエラーを投げる', () => {
@@ -60,8 +62,10 @@ describe('playerActionParser', () => {
       const result = extractPlayerLeaveInfoFromLog(logLine);
 
       expect(result.logType).toBe('playerLeave');
-      expect(result.playerName).toBe('TestPlayer');
-      expect(result.playerId).toBe('usr_12345678-1234-1234-1234-123456789abc');
+      expect(result.playerName.value).toBe('TestPlayer');
+      expect(result.playerId?.value).toBe(
+        'usr_12345678-1234-1234-1234-123456789abc',
+      );
       expect(result.leaveDate).toEqual(new Date('2025-01-08T00:22:04'));
     });
 
@@ -71,7 +75,7 @@ describe('playerActionParser', () => {
       );
 
       const result = extractPlayerLeaveInfoFromLog(logLine);
-      expect(result.playerName).toBe('プレイヤー ⁄ A');
+      expect(result.playerName.value).toBe('プレイヤー ⁄ A');
     });
 
     it('プレイヤーIDがない退出ログを処理できる', () => {
@@ -80,7 +84,7 @@ describe('playerActionParser', () => {
       );
 
       const result = extractPlayerLeaveInfoFromLog(logLine);
-      expect(result.playerName).toBe('TestPlayer');
+      expect(result.playerName.value).toBe('TestPlayer');
       expect(result.playerId).toBeNull();
     });
 

--- a/electron/module/vrchatLog/parsers/playerActionParser.ts
+++ b/electron/module/vrchatLog/parsers/playerActionParser.ts
@@ -1,18 +1,19 @@
 import * as datefns from 'date-fns';
-import type { VRChatLogLine } from '../model';
+import type { VRChatLogLine, VRChatPlayerId, VRChatPlayerName } from '../model';
+import { OptionalVRChatPlayerIdSchema, VRChatPlayerNameSchema } from '../model';
 
 export interface VRChatPlayerJoinLog {
   logType: 'playerJoin';
   joinDate: Date;
-  playerName: string;
-  playerId: string | null;
+  playerName: VRChatPlayerName;
+  playerId: VRChatPlayerId | null;
 }
 
 export interface VRChatPlayerLeaveLog {
   logType: 'playerLeave';
   leaveDate: Date;
-  playerName: string;
-  playerId: string | null;
+  playerName: VRChatPlayerName;
+  playerId: VRChatPlayerId | null;
 }
 
 /**
@@ -44,11 +45,17 @@ export const extractPlayerJoinInfoFromLog = (
     new Date(),
   );
 
+  // valueObjectsを使用して型安全に検証
+  const validatedPlayerName = VRChatPlayerNameSchema.parse(playerName);
+  const validatedPlayerId = OptionalVRChatPlayerIdSchema.parse(
+    playerId || null,
+  );
+
   return {
     logType: 'playerJoin',
     joinDate: joinDateTime,
-    playerName,
-    playerId: playerId || null,
+    playerName: validatedPlayerName,
+    playerId: validatedPlayerId,
   };
 };
 
@@ -81,10 +88,16 @@ export const extractPlayerLeaveInfoFromLog = (
     new Date(),
   );
 
+  // valueObjectsを使用して型安全に検証
+  const validatedPlayerName = VRChatPlayerNameSchema.parse(playerName);
+  const validatedPlayerId = OptionalVRChatPlayerIdSchema.parse(
+    playerId || null,
+  );
+
   return {
     logType: 'playerLeave',
     leaveDate: leaveDateTime,
-    playerName,
-    playerId: playerId || null,
+    playerName: validatedPlayerName,
+    playerId: validatedPlayerId,
   };
 };

--- a/electron/module/vrchatLog/parsers/playerActionParser.ts
+++ b/electron/module/vrchatLog/parsers/playerActionParser.ts
@@ -1,0 +1,90 @@
+import * as datefns from 'date-fns';
+import type { VRChatLogLine } from '../model';
+
+export interface VRChatPlayerJoinLog {
+  logType: 'playerJoin';
+  joinDate: Date;
+  playerName: string;
+  playerId: string | null;
+}
+
+export interface VRChatPlayerLeaveLog {
+  logType: 'playerLeave';
+  leaveDate: Date;
+  playerName: string;
+  playerId: string | null;
+}
+
+/**
+ * プレイヤーアクション（参加・退出）ログのパース機能
+ */
+
+/**
+ * プレイヤー参加ログから情報を抽出
+ * @param logLine プレイヤー参加のログ行
+ * @returns プレイヤー参加情報
+ * @throws ログ行が期待される形式と一致しない場合
+ */
+export const extractPlayerJoinInfoFromLog = (
+  logLine: VRChatLogLine,
+): VRChatPlayerJoinLog => {
+  // 2025.01.07 23:25:34 Log        -  [Behaviour] OnPlayerJoined プレイヤーA (usr_8862b082-dbc8-4b6d-8803-e834f833b498)
+  const regex =
+    /(\d{4}\.\d{2}\.\d{2}) (\d{2}:\d{2}:\d{2}).*\[Behaviour\] OnPlayerJoined (.+?)(?:\s+\((usr_[^)]+)\))?$/;
+  const matches = logLine.value.match(regex);
+
+  if (!matches) {
+    throw new Error('Log line did not match the expected format');
+  }
+
+  const [date, time, playerName, playerId] = matches.slice(1);
+  const joinDateTime = datefns.parse(
+    `${date} ${time}`,
+    'yyyy.MM.dd HH:mm:ss',
+    new Date(),
+  );
+
+  return {
+    logType: 'playerJoin',
+    joinDate: joinDateTime,
+    playerName,
+    playerId: playerId || null,
+  };
+};
+
+/**
+ * プレイヤー退出ログから情報を抽出
+ * @param logLine プレイヤー退出のログ行
+ * @returns プレイヤー退出情報
+ * @throws ログ行が期待される形式と一致しない場合
+ */
+export const extractPlayerLeaveInfoFromLog = (
+  logLine: VRChatLogLine,
+): VRChatPlayerLeaveLog => {
+  // プレイヤー名は空白を含む場合がある
+  // 2025.01.08 00:22:04 Log        -  [Behaviour] OnPlayerLeft プレイヤー ⁄ A (usr_34a27988-a7e4-4d5e-a49a-ae5975422779)
+  // 2025.02.22 21:14:48 Debug      -  [Behaviour] OnPlayerLeft tkt (usr_3ba2a992-724c-4463-bc75-7e9f6674e8e0)
+  const regex =
+    /(\d{4}\.\d{2}\.\d{2})\s+(\d{2}:\d{2}:\d{2})\s+\S+\s+-\s+\[Behaviour\] OnPlayerLeft (.+?)(?:\s+\((usr_[^)]+)\))?$/;
+  const matches = logLine.value.match(regex);
+
+  if (!matches) {
+    throw new Error(
+      `Log line did not match the expected format: ${logLine.value}`,
+    );
+  }
+
+  const [, date, time, playerName, playerId] = matches;
+  const leaveDateTime = datefns.parse(
+    `${date.replace(/\./g, '-')} ${time}`,
+    'yyyy-MM-dd HH:mm:ss',
+    new Date(),
+  );
+
+  return {
+    logType: 'playerLeave',
+    leaveDate: leaveDateTime,
+    playerName,
+    playerId: playerId || null,
+  };
+};

--- a/electron/module/vrchatLog/parsers/worldJoinParser.test.ts
+++ b/electron/module/vrchatLog/parsers/worldJoinParser.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { VRChatLogLineSchema } from '../model';
+import { extractWorldJoinInfoFromLogs } from './worldJoinParser';
+
+describe('worldJoinParser', () => {
+  describe('extractWorldJoinInfoFromLogs', () => {
+    it('ワールド参加ログから正しい情報を抽出できる', () => {
+      const logLines = [
+        VRChatLogLineSchema.parse(
+          '2023.10.08 15:30:45 Log        -  [Behaviour] Joining wrld_12345678-1234-1234-1234-123456789abc:12345',
+        ),
+        VRChatLogLineSchema.parse(
+          '2023.10.08 15:30:46 Log        -  [Behaviour] Joining or Creating Room: Test World',
+        ),
+      ];
+
+      const result = extractWorldJoinInfoFromLogs(logLines, 0);
+
+      expect(result).not.toBeNull();
+      expect(result?.logType).toBe('worldJoin');
+      expect(result?.worldId).toBe('wrld_12345678-1234-1234-1234-123456789abc');
+      expect(result?.worldInstanceId).toBe('12345');
+      expect(result?.worldName).toBe('Test World');
+      expect(result?.joinDate).toEqual(new Date('2023-10-08T15:30:45'));
+    });
+
+    it('ワールド名が見つからない場合はエラーを投げる', () => {
+      const logLines = [
+        VRChatLogLineSchema.parse(
+          '2023.10.08 15:30:45 Log        -  [Behaviour] Joining wrld_12345678-1234-1234-1234-123456789abc:12345',
+        ),
+      ];
+
+      expect(() => extractWorldJoinInfoFromLogs(logLines, 0)).toThrow(
+        'Failed to extract world name from the subsequent log entries',
+      );
+    });
+
+    it('無効なワールドIDの場合はエラーを投げる', () => {
+      const logLines = [
+        VRChatLogLineSchema.parse(
+          '2023.10.08 15:30:45 Log        -  [Behaviour] Joining wrld_1234567-1234-1234-1234-123456789abc:12345',
+        ),
+        VRChatLogLineSchema.parse(
+          '2023.10.08 15:30:46 Log        -  [Behaviour] Joining or Creating Room: Test World',
+        ),
+      ];
+
+      expect(() => extractWorldJoinInfoFromLogs(logLines, 0)).toThrow(
+        'WorldId did not match the expected format',
+      );
+    });
+
+    it('ログ形式が不正な場合はnullを返す', () => {
+      const logLines = [
+        VRChatLogLineSchema.parse('2023.10.08 15:30:45 Log - Invalid format'),
+      ];
+
+      const result = extractWorldJoinInfoFromLogs(logLines, 0);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/electron/module/vrchatLog/parsers/worldJoinParser.test.ts
+++ b/electron/module/vrchatLog/parsers/worldJoinParser.test.ts
@@ -18,9 +18,11 @@ describe('worldJoinParser', () => {
 
       expect(result).not.toBeNull();
       expect(result?.logType).toBe('worldJoin');
-      expect(result?.worldId).toBe('wrld_12345678-1234-1234-1234-123456789abc');
-      expect(result?.worldInstanceId).toBe('12345');
-      expect(result?.worldName).toBe('Test World');
+      expect(result?.worldId.value).toBe(
+        'wrld_12345678-1234-1234-1234-123456789abc',
+      );
+      expect(result?.worldInstanceId.value).toBe('12345');
+      expect(result?.worldName.value).toBe('Test World');
       expect(result?.joinDate).toEqual(new Date('2023-10-08T15:30:45'));
     });
 
@@ -47,7 +49,7 @@ describe('worldJoinParser', () => {
       ];
 
       expect(() => extractWorldJoinInfoFromLogs(logLines, 0)).toThrow(
-        'WorldId did not match the expected format',
+        'Invalid VRChat World ID format. Expected: wrld_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
       );
     });
 

--- a/electron/module/vrchatLog/parsers/worldJoinParser.ts
+++ b/electron/module/vrchatLog/parsers/worldJoinParser.ts
@@ -1,14 +1,22 @@
-import type { VRChatLogLine } from '../model';
-import { isValidWorldId, parseLogDateTime } from './baseParser';
-
-type WorldId = `wrld_${string}`;
+import type {
+  VRChatLogLine,
+  VRChatWorldId,
+  VRChatWorldInstanceId,
+  VRChatWorldName,
+} from '../model';
+import {
+  VRChatWorldIdSchema,
+  VRChatWorldInstanceIdSchema,
+  VRChatWorldNameSchema,
+} from '../model';
+import { parseLogDateTime } from './baseParser';
 
 export interface VRChatWorldJoinLog {
   logType: 'worldJoin';
   joinDate: Date;
-  worldId: WorldId;
-  worldInstanceId: string;
-  worldName: string;
+  worldId: VRChatWorldId;
+  worldInstanceId: VRChatWorldInstanceId;
+  worldName: VRChatWorldName;
 }
 
 /**
@@ -39,9 +47,9 @@ export const extractWorldJoinInfoFromLogs = (
   const worldId = matches[3];
   const instanceId = matches[4];
 
-  if (!isValidWorldId(worldId)) {
-    throw new Error('WorldId did not match the expected format');
-  }
+  // valueObjectsを使用して型安全に検証
+  const validatedWorldId = VRChatWorldIdSchema.parse(worldId);
+  const validatedInstanceId = VRChatWorldInstanceIdSchema.parse(instanceId);
 
   let foundWorldName: string | null = null;
 
@@ -56,12 +64,14 @@ export const extractWorldJoinInfoFromLogs = (
 
   if (foundWorldName) {
     const joinDate = parseLogDateTime(date, time);
+    const validatedWorldName = VRChatWorldNameSchema.parse(foundWorldName);
+
     return {
       logType: 'worldJoin',
       joinDate,
-      worldInstanceId: instanceId,
-      worldId: worldId as `wrld_${string}`,
-      worldName: foundWorldName,
+      worldInstanceId: validatedInstanceId,
+      worldId: validatedWorldId,
+      worldName: validatedWorldName,
     };
   }
 

--- a/electron/module/vrchatLog/parsers/worldJoinParser.ts
+++ b/electron/module/vrchatLog/parsers/worldJoinParser.ts
@@ -1,0 +1,71 @@
+import type { VRChatLogLine } from '../model';
+import { isValidWorldId, parseLogDateTime } from './baseParser';
+
+type WorldId = `wrld_${string}`;
+
+export interface VRChatWorldJoinLog {
+  logType: 'worldJoin';
+  joinDate: Date;
+  worldId: WorldId;
+  worldInstanceId: string;
+  worldName: string;
+}
+
+/**
+ * ワールド参加ログのパース機能
+ */
+
+/**
+ * ログエントリーからワールド参加情報を抽出
+ * @param logLines ログ行の配列
+ * @param index 現在処理中のログ行のインデックス
+ * @returns ワールド参加情報、または抽出できない場合null
+ */
+export const extractWorldJoinInfoFromLogs = (
+  logLines: VRChatLogLine[],
+  index: number,
+): VRChatWorldJoinLog | null => {
+  const logEntry = logLines[index];
+  const regex =
+    /(\d{4}\.\d{2}\.\d{2}) (\d{2}:\d{2}:\d{2}) .* \[Behaviour\] Joining (wrld_[a-f0-9-]+):(.*)/;
+  const matches = logEntry.value.match(regex);
+
+  if (!matches || matches.length < 4) {
+    return null;
+  }
+
+  const date = matches[1];
+  const time = matches[2];
+  const worldId = matches[3];
+  const instanceId = matches[4];
+
+  if (!isValidWorldId(worldId)) {
+    throw new Error('WorldId did not match the expected format');
+  }
+
+  let foundWorldName: string | null = null;
+
+  // 後続のログ行からワールド名を抽出
+  for (const l of logLines.slice(index + 1)) {
+    const worldNameRegex = /\[Behaviour\] Joining or Creating Room: (.+)/;
+    const [, worldName] = l.value.match(worldNameRegex) || [];
+    if (worldName && !foundWorldName) {
+      foundWorldName = worldName;
+    }
+  }
+
+  if (foundWorldName) {
+    const joinDate = parseLogDateTime(date, time);
+    return {
+      logType: 'worldJoin',
+      joinDate,
+      worldInstanceId: instanceId,
+      worldId: worldId as `wrld_${string}`,
+      worldName: foundWorldName,
+    };
+  }
+
+  throw new Error(
+    'Failed to extract world name from the subsequent log entries',
+  );
+};

--- a/electron/module/vrchatLog/service.spec.ts
+++ b/electron/module/vrchatLog/service.spec.ts
@@ -275,8 +275,10 @@ describe('extractPlayerJoinInfoFromLog', () => {
     );
     const result = service.extractPlayerJoinInfoFromLog(logLine);
     expect(result.logType).toBe('playerJoin');
-    expect(result.playerName).toBe('プレイヤーA');
-    expect(result.playerId).toBe('usr_8862b082-dbc8-4b6d-8803-e834f833b498');
+    expect(result.playerName.value).toBe('プレイヤーA');
+    expect(result.playerId?.value).toBe(
+      'usr_8862b082-dbc8-4b6d-8803-e834f833b498',
+    );
     expect(result.joinDate).toBeInstanceOf(Date);
   });
 
@@ -286,7 +288,7 @@ describe('extractPlayerJoinInfoFromLog', () => {
     );
     const result = service.extractPlayerJoinInfoFromLog(logLine);
     expect(result.logType).toBe('playerJoin');
-    expect(result.playerName).toBe('プレイヤーB');
+    expect(result.playerName.value).toBe('プレイヤーB');
     expect(result.playerId).toBe(null);
     expect(result.joinDate).toBeInstanceOf(Date);
   });

--- a/electron/module/vrchatLog/service.ts
+++ b/electron/module/vrchatLog/service.ts
@@ -1,50 +1,43 @@
-import * as nodeFs from 'node:fs';
-import readline from 'node:readline';
-import * as datefns from 'date-fns';
 import * as neverthrow from 'neverthrow';
 import { match } from 'ts-pattern';
-import * as fs from '../../lib/wrappedFs';
-
-import path from 'node:path';
-import { getAppUserDataPath } from '../../lib/wrappedApp';
 import type {
   VRChatLogFilePath,
   VRChatLogFilesDirPath,
 } from '../vrchatLogFileDir/model';
 import * as vrchatLogFileDirService from '../vrchatLogFileDir/service';
-import type { VRChatPhotoDirPath } from '../vrchatPhoto/valueObjects';
-import { createVRChatWorldJoinLogFromPhoto } from '../vrchatWorldJoinLogFromPhoto/service';
 import { VRChatLogFileError } from './error';
+import type { VRChatLogStoreFilePath } from './model';
+
+// パーサー機能のインポート
 import {
-  type VRChatLogLine,
-  VRChatLogLineSchema,
-  type VRChatLogStoreFilePath,
-  VRChatLogStoreFilePathRegex,
-  VRChatLogStoreFilePathSchema,
-  createTimestampedLogFilePath,
-} from './model';
+  type VRChatPlayerJoinLog,
+  type VRChatPlayerLeaveLog,
+  type VRChatWorldJoinLog,
+  convertLogLinesToWorldAndPlayerJoinLogInfos,
+  extractPlayerJoinInfoFromLog,
+  filterLogLinesByDate,
+} from './parsers';
 
-type WorldId = `wrld_${string}`;
-export interface VRChatWorldJoinLog {
-  logType: 'worldJoin';
-  joinDate: Date;
-  worldId: WorldId;
-  worldInstanceId: string;
-  worldName: string;
-}
-export interface VRChatPlayerJoinLog {
-  logType: 'playerJoin';
-  joinDate: Date;
-  playerName: string;
-  playerId: string | null;
-}
-export interface VRChatPlayerLeaveLog {
-  logType: 'playerLeave';
-  leaveDate: Date;
-  playerName: string;
-  playerId: string | null;
-}
+// ファイルハンドラー機能のインポート
+import {
+  appendLoglinesToFile,
+  getLegacyLogStoreFilePath,
+  getLogLinesByLogFilePathList,
+  getLogStoreFilePathForDate,
+  getLogStoreFilePathsInRange,
+  importLogLinesFromLogPhotoDirPath,
+} from './fileHandlers';
 
+/**
+ * VRChatログサービスのメインインターフェース
+ * ログファイルの処理と情報抽出を提供
+ */
+
+/**
+ * 指定されたログディレクトリからVRChatログ情報を取得
+ * @param logFilesDir VRChatログファイルのディレクトリパス
+ * @returns ワールド参加・プレイヤー参加/退出ログの配列
+ */
 export const getVRChaLogInfoFromLogPath = async (
   logFilesDir: VRChatLogFilesDirPath,
 ): Promise<
@@ -72,6 +65,11 @@ export const getVRChaLogInfoFromLogPath = async (
   return neverthrow.ok(logInfoList.value);
 };
 
+/**
+ * ログファイルパスのリストからVRChatログ情報を取得
+ * @param logFilePathList ログファイルパスの配列
+ * @returns ワールド参加・プレイヤー参加/退出ログの配列
+ */
 export const getVRChaLogInfoByLogFilePathList = async (
   logFilePathList: (VRChatLogFilePath | VRChatLogStoreFilePath)[],
 ): Promise<
@@ -103,537 +101,18 @@ export const getVRChaLogInfoByLogFilePathList = async (
   return neverthrow.ok(logInfoList);
 };
 
-export const getLogLinesByLogFilePathList = async (props: {
-  logFilePathList: (VRChatLogFilePath | VRChatLogStoreFilePath)[];
-  includesList: string[];
-}): Promise<neverthrow.Result<VRChatLogLine[], VRChatLogFileError>> => {
-  const logLineList: VRChatLogLine[] = [];
-  const errors: VRChatLogFileError[] = [];
-  await Promise.all(
-    props.logFilePathList.map(async (logFilePath) => {
-      const result = await getLogLinesFromLogFileName({
-        logFilePath,
-        includesList: props.includesList,
-      });
-      if (result.isErr()) {
-        errors.push(result.error);
-        return;
-      }
-      logLineList.push(
-        ...result.value.map((line) => VRChatLogLineSchema.parse(line)),
-      );
-    }),
-  );
-
-  if (errors.length > 0) {
-    return neverthrow.err(errors[0]);
-  }
-
-  return neverthrow.ok(logLineList);
+// ファイルハンドラー機能の再エクスポート
+export {
+  getLogLinesByLogFilePathList,
+  getLogStoreFilePathForDate,
+  getLegacyLogStoreFilePath,
+  getLogStoreFilePathsInRange,
+  appendLoglinesToFile,
+  importLogLinesFromLogPhotoDirPath,
 };
 
-const getLogLinesFromLogFileName = async (props: {
-  logFilePath: VRChatLogFilePath | VRChatLogStoreFilePath;
-  includesList: string[];
-}): Promise<neverthrow.Result<string[], VRChatLogFileError>> => {
-  // ファイルが存在するか確認
-  if (!nodeFs.existsSync(props.logFilePath.value)) {
-    // ファイルが存在しない場合は空の配列を返す
-    return neverthrow.ok([]);
-  }
+// 型定義の再エクスポート
+export type { VRChatWorldJoinLog, VRChatPlayerJoinLog, VRChatPlayerLeaveLog };
 
-  const stream = fs.createReadStream(props.logFilePath.value);
-  const reader = readline.createInterface({
-    input: stream,
-    crlfDelay: Number.POSITIVE_INFINITY,
-  });
-  const lines: string[] = [];
-  reader.on('line', (line) => {
-    // worldJoin も playerJoin も含むログも Join が含まれる
-    // includesList の配列の中のどれかと一致したら追加
-    if (props.includesList.some((include) => line.includes(include))) {
-      lines.push(line);
-    }
-  });
-  await Promise.all([
-    new Promise((resolve) => {
-      stream.on('close', () => {
-        resolve(null);
-      });
-    }),
-  ]);
-  return neverthrow.ok(lines);
-};
-
-const convertLogLinesToWorldAndPlayerJoinLogInfos = (
-  logLines: VRChatLogLine[],
-): (VRChatWorldJoinLog | VRChatPlayerJoinLog | VRChatPlayerLeaveLog)[] => {
-  const logInfos: (
-    | VRChatWorldJoinLog
-    | VRChatPlayerJoinLog
-    | VRChatPlayerLeaveLog
-  )[] = [];
-  for (const [index, l] of logLines.entries()) {
-    if (l.value.includes('Joining wrld')) {
-      const info = extractWorldJoinInfoFromLogs(logLines, index);
-      if (info) {
-        logInfos.push(info);
-      }
-    }
-    if (l.value.includes('[Behaviour] OnPlayerJoined')) {
-      const info = extractPlayerJoinInfoFromLog(l);
-      if (info) {
-        logInfos.push(info);
-      }
-    }
-    if (
-      l.value.includes('OnPlayerLeft') &&
-      !l.value.includes('OnPlayerLeftRoom')
-    ) {
-      const info = extractPlayerLeaveInfoFromLog(l);
-      if (info) {
-        logInfos.push(info);
-      }
-    }
-  }
-
-  return logInfos;
-};
-
-const extractWorldJoinInfoFromLogs = (
-  logLines: VRChatLogLine[],
-  index: number,
-): VRChatWorldJoinLog | null => {
-  const validateWorldId = (value: string): value is WorldId => {
-    const regex = /^wrld_[a-f0-9-]+$/;
-    return regex.test(value);
-  };
-
-  const logEntry = logLines[index];
-  const regex =
-    /(\d{4}\.\d{2}\.\d{2}) (\d{2}:\d{2}:\d{2}) .* \[Behaviour\] Joining (wrld_[a-f0-9-]+):(.*)/;
-  const matches = logEntry.value.match(regex);
-
-  if (!matches || matches.length < 4) {
-    return null;
-  }
-  const date = matches[1].replace(/\./g, '-');
-  const time = matches[2].replace(/:/g, '-');
-  const worldId = matches[3];
-  const instanceId = matches[4];
-
-  if (!validateWorldId(worldId)) {
-    throw new Error('WorldId did not match the expected format');
-  }
-
-  const [year, month, day] = date.split('-');
-  const [hour, minute, second] = time.split('-');
-  let foundWorldName: string | null = null;
-  // Extracting world name from the subsequent lines
-  for (const l of logLines.slice(index + 1)) {
-    const worldNameRegex = /\[Behaviour\] Joining or Creating Room: (.+)/;
-    const [, worldName] = l.value.match(worldNameRegex) || [];
-    if (worldName && !foundWorldName) {
-      foundWorldName = worldName;
-    }
-  }
-
-  if (foundWorldName) {
-    const joinDate = datefns.parse(
-      `${year}-${month}-${day} ${hour}:${minute}:${second}`,
-      'yyyy-MM-dd HH:mm:ss',
-      new Date(),
-    );
-    return {
-      logType: 'worldJoin',
-      joinDate,
-      worldInstanceId: instanceId,
-      worldId,
-      worldName: foundWorldName,
-    };
-  }
-
-  throw new Error(
-    'Failed to extract world name from the subsequent log entries',
-  );
-};
-
-export const extractPlayerJoinInfoFromLog = (
-  logLine: VRChatLogLine,
-): VRChatPlayerJoinLog => {
-  // 2025.01.07 23:25:34 Log        -  [Behaviour] OnPlayerJoined プレイヤーA (usr_8862b082-dbc8-4b6d-8803-e834f833b498)
-  const regex =
-    /(\d{4}\.\d{2}\.\d{2}) (\d{2}:\d{2}:\d{2}).*\[Behaviour\] OnPlayerJoined (.+?)(?:\s+\((usr_[^)]+)\))?$/;
-  const matches = logLine.value.match(regex);
-
-  if (!matches) {
-    throw new Error('Log line did not match the expected format');
-  }
-
-  const [date, time, playerName, playerId] = matches.slice(1);
-  const joinDateTime = datefns.parse(
-    `${date} ${time}`,
-    'yyyy.MM.dd HH:mm:ss',
-    new Date(),
-  );
-
-  return {
-    logType: 'playerJoin',
-    joinDate: joinDateTime,
-    playerName,
-    playerId: playerId || null,
-  };
-};
-
-const extractPlayerLeaveInfoFromLog = (
-  logLine: VRChatLogLine,
-): VRChatPlayerLeaveLog => {
-  // 下記のように、プレイヤー名は空白を含む場合がある
-  // 2025.01.08 00:22:04 Log        -  [Behaviour] OnPlayerLeft プレイヤー ⁄ A (usr_34a27988-a7e4-4d5e-a49a-ae5975422779)
-  // 2025.02.22 21:14:48 Debug      -  [Behaviour] OnPlayerLeft tkt (usr_3ba2a992-724c-4463-bc75-7e9f6674e8e0)
-  const regex =
-    /(\d{4}\.\d{2}\.\d{2})\s+(\d{2}:\d{2}:\d{2})\s+\S+\s+-\s+\[Behaviour\] OnPlayerLeft (.+?)(?:\s+\((usr_[^)]+)\))?$/;
-  const matches = logLine.value.match(regex);
-  if (!matches) {
-    throw new Error(
-      `Log line did not match the expected format: ${logLine.value}`,
-    );
-  }
-
-  const [, date, time, playerName, playerId] = matches;
-  const leaveDateTime = datefns.parse(
-    `${date.replace(/\./g, '-')} ${time}`,
-    'yyyy-MM-dd HH:mm:ss',
-    new Date(),
-  );
-
-  return {
-    logType: 'playerLeave',
-    leaveDate: leaveDateTime,
-    playerName,
-    playerId: playerId || null,
-  };
-};
-
-/**
- * logStoreディレクトリのパスを取得する
- *
- * logStoreディレクトリは、VRChatログから抽出した必要な情報のみを保存するディレクトリです。
- * これは月ごとに整理され、`logStore/YYYY-MM/logStore-YYYY-MM.txt`という形式で保存されます。
- * 月ごとのログファイルがサイズ制限（10MB）を超えると、タイムスタンプ付きの新しいファイルが作成されます。
- */
-const getLogStoreDir = (): string => {
-  return path.join(getAppUserDataPath(), 'logStore');
-};
-
-/**
- * logStoreディレクトリを初期化する
- * ディレクトリが存在しない場合は作成する
- */
-const initLogStoreDir = (): void => {
-  const logStoreDir = getLogStoreDir();
-  if (!nodeFs.existsSync(logStoreDir)) {
-    nodeFs.mkdirSync(logStoreDir, { recursive: true });
-  }
-};
-
-/**
- * 指定された日付に基づいてログストアファイルのパスを生成する
- * 日付が指定されない場合は現在の日付を使用する
- */
-export const getLogStoreFilePathForDate = (
-  date: Date = new Date(),
-): VRChatLogStoreFilePath => {
-  const yearMonth = datefns.format(date, 'yyyy-MM');
-  const logStoreFilePath = path.join(
-    getLogStoreDir(),
-    yearMonth,
-    `logStore-${yearMonth}.txt`,
-  );
-  return VRChatLogStoreFilePathSchema.parse(logStoreFilePath);
-};
-
-/**
- * 旧形式のログファイルパスを取得する
- * ファイルが存在しない場合はnullを返す
- */
-export const getLegacyLogStoreFilePath =
-  async (): Promise<VRChatLogStoreFilePath | null> => {
-    const legacyPath = path.join(getLogStoreDir(), 'logStore.txt');
-    if (!nodeFs.existsSync(legacyPath)) {
-      return null;
-    }
-    return VRChatLogStoreFilePathSchema.parse(legacyPath);
-  };
-
-/**
- * 指定された日付範囲のログストアファイルのパスを取得する
- * 新形式のログファイルのみ含める
- * タイムスタンプ付きの追加ファイル（logStore-YYYY-MM-YYYYMMDDHHMMSS.txt）も含める
- */
-export const getLogStoreFilePathsInRange = async (
-  startDate: Date,
-  currentDate: Date,
-): Promise<VRChatLogStoreFilePath[]> => {
-  // 重複を避けるためにSetを使用
-  const logFilePathSet = new Set<string>();
-  let targetDate = datefns.startOfMonth(startDate);
-  const endDate = datefns.endOfMonth(currentDate);
-
-  while (
-    datefns.isBefore(targetDate, endDate) ||
-    datefns.isSameDay(targetDate, endDate)
-  ) {
-    // 標準のログファイル（月毎）を取得
-    const yearMonth = datefns.format(targetDate, 'yyyy-MM');
-    const monthDir = path.join(getLogStoreDir(), yearMonth);
-    const standardLogFilePath = getLogStoreFilePathForDate(targetDate);
-
-    // 標準のログファイルを追加（重複を避けるためにSetを使用）
-    logFilePathSet.add(standardLogFilePath.value);
-
-    // 同じ月のタイムスタンプ付きのログファイルを検索
-    if (nodeFs.existsSync(monthDir)) {
-      try {
-        const files = nodeFs.readdirSync(monthDir);
-        const timestampedLogFiles = files.filter((file) =>
-          file.match(VRChatLogStoreFilePathRegex),
-        );
-
-        // タイムスタンプ付きのファイルをパスに追加
-        for (const file of timestampedLogFiles) {
-          const fullPath = path.join(monthDir, file);
-          logFilePathSet.add(fullPath);
-        }
-      } catch (err) {
-        console.error(`Error reading directory ${monthDir}:`, err);
-      }
-    }
-
-    targetDate = datefns.addMonths(targetDate, 1);
-  }
-
-  // SetからVRChatLogStoreFilePathの配列に変換して返す
-  return Array.from(logFilePathSet).map((p) =>
-    VRChatLogStoreFilePathSchema.parse(p),
-  );
-};
-
-/**
- * 必要になるlog行を app 内のファイルに保存しておく
- * 最後に保存した日時以降のログ行のみを日付順に保存する
- * 最初は全部保存しようとして被ってたら辞めるでもいいかな
- * ログの日付に基づいて適切な月のファイルに書き込む
- */
-export const appendLoglinesToFile = async (props: {
-  logLines: VRChatLogLine[];
-  logStoreFilePath?: VRChatLogStoreFilePath; // オプショナルに変更
-}): Promise<neverthrow.Result<void, never>> => {
-  // ログが空の場合は何もしない
-  if (props.logLines.length === 0) {
-    return neverthrow.ok(undefined);
-  }
-  // ログを日付ごとにグループ化
-  const logsByMonth = new Map<string, VRChatLogLine[]>();
-
-  for (const logLine of props.logLines) {
-    // ログから日付を抽出
-    const dateMatch = logLine.value.match(/^(\d{4})\.(\d{2})\.(\d{2})/);
-    if (!dateMatch) {
-      // 日付が抽出できない場合は現在の月に追加
-      const key = datefns.format(new Date(), 'yyyy-MM');
-      const monthLogs = logsByMonth.get(key) || [];
-      monthLogs.push(logLine);
-      logsByMonth.set(key, monthLogs);
-      continue;
-    }
-
-    const year = dateMatch[1];
-    const month = dateMatch[2];
-    const key = `${year}-${month}`;
-
-    const monthLogs = logsByMonth.get(key) || [];
-    monthLogs.push(logLine);
-    logsByMonth.set(key, monthLogs);
-  }
-
-  // 各月のログを対応するファイルに書き込む
-  for (const [yearMonth, logs] of logsByMonth.entries()) {
-    const [year, month] = yearMonth.split('-');
-    const date = datefns.parse(`${year}-${month}-01`, 'yyyy-MM-dd', new Date());
-
-    // 月別のディレクトリを作成
-    const monthDir = path.join(getLogStoreDir(), yearMonth);
-
-    // ログストアのルートディレクトリを先に確認・作成
-    initLogStoreDir();
-
-    // 月別ディレクトリを作成
-    if (!nodeFs.existsSync(monthDir)) {
-      nodeFs.mkdirSync(monthDir, { recursive: true });
-    }
-
-    const logStoreFilePath = getLogStoreFilePathForDate(date);
-    const isExists = await fs.existsSyncSafe(logStoreFilePath.value);
-
-    // ファイルサイズをチェック
-    if (isExists) {
-      const stats = nodeFs.statSync(logStoreFilePath.value);
-      if (stats.size >= 10 * 1024 * 1024) {
-        // 10MB
-        // ファイルサイズが上限を超えている場合は、新しいファイルを作成
-        const timestamp = new Date();
-        const newFilePath = createTimestampedLogFilePath(
-          monthDir,
-          yearMonth,
-          timestamp,
-        );
-
-        // 新しいファイルに直接書き込み
-        const newLog = `${logs.map((l) => l.value).join('\n')}\n`;
-        const writeResult = await fs.writeFileSyncSafe(newFilePath, newLog);
-        if (writeResult.isErr()) {
-          throw writeResult.error;
-        }
-        continue;
-      }
-    }
-
-    // 既存のログ行をSetとして保持
-    const existingLines = new Set<string>();
-
-    if (isExists) {
-      const readResult = await fs.readFileSyncSafe(logStoreFilePath.value);
-      if (readResult.isOk()) {
-        const content = readResult.value.toString();
-        for (const line of content.split('\n')) {
-          if (line) {
-            existingLines.add(line);
-          }
-        }
-      }
-    }
-
-    // 重複を除外して新しいログ行を追加
-    const newLines = logs.filter((log) => !existingLines.has(log.value));
-    if (newLines.length === 0) {
-      continue;
-    }
-
-    const newLog = `${newLines.map((l) => l.value).join('\n')}\n`;
-    const writeResult = await fs.writeFileSyncSafe(
-      logStoreFilePath.value,
-      newLog,
-    );
-    if (writeResult.isErr()) {
-      throw writeResult.error;
-    }
-  }
-
-  return neverthrow.ok(undefined);
-};
-
-import { glob } from 'glob';
-import type { VRChatWorldJoinLogFromPhoto } from '../vrchatWorldJoinLogFromPhoto/vrchatWorldJoinLogFromPhoto.model';
-/**
- * 旧Appで生成したログファイル(写真)をインポートする
- *
- * 写真のあるディレクトリに 下記の形式で保存されているので、parse して
- * `VRChat_2025-01-06_23-18-51.000_wrld_f5db5fd3-7541-407e-a218-04fbdd84f2b7.jpeg`
- * r/VRChat_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2}.[0-9]{3}_wrld_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.[a-z]{3}
- *
- * VRChatWorldJoinLog に変換して返す
- */
-const getLogLinesFromLogPhotoDirPath = async ({
-  vrChatPhotoDirPath,
-}: { vrChatPhotoDirPath: VRChatPhotoDirPath }): Promise<
-  VRChatWorldJoinLogFromPhoto[]
-> => {
-  const globPath = path.posix.join(
-    vrChatPhotoDirPath.value,
-    '**',
-    'VRChat_*_wrld_*',
-  );
-  // 正規表現にマッチするファイルを再起的に取得していく
-  const logPhotoFilePathList = await glob(globPath);
-
-  // r/VRChat_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2}.[0-9]{3}_wrld_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.[a-z]
-  // を parse して VRChatWorldJoinLog に変換する
-  const worldJoinLogList = logPhotoFilePathList
-    .map((filePath) => {
-      const regex =
-        /VRChat_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.\d{3})_wrld_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.[a-z]+/;
-      const matches = filePath.match(regex);
-      if (!matches) {
-        return null;
-      }
-      return {
-        // ファイル名の日時はlocal time なので、そのままparseする
-        joinDate: datefns.parse(
-          matches[1],
-          'yyyy-MM-dd_HH-mm-ss.SSS',
-          new Date(),
-        ),
-        worldId: `wrld_${matches[2]}` as WorldId,
-      };
-    })
-    .filter((log) => log !== null);
-  return worldJoinLogList;
-};
-
-/**
- * 写真として保存されているワールドへのJoinログをデータベースに保存する
- */
-export const importLogLinesFromLogPhotoDirPath = async ({
-  vrChatPhotoDirPath,
-}: { vrChatPhotoDirPath: VRChatPhotoDirPath }): Promise<void> => {
-  const logLines = await getLogLinesFromLogPhotoDirPath({
-    vrChatPhotoDirPath,
-  });
-
-  const worldJoinLogs: VRChatWorldJoinLogFromPhoto[] = logLines.map((log) => ({
-    joinDate: log.joinDate,
-    worldId: log.worldId,
-  }));
-
-  await createVRChatWorldJoinLogFromPhoto(worldJoinLogs);
-};
-
-/**
- * ログ行を日付でフィルタリングする
- * 指定された日付以降のログ行のみを返す
- *
- * @param logLines フィルタリング対象のログ行の配列
- * @param startDate フィルタリングの基準となる日付（この日付以降のログを含む）
- * @returns フィルタリングされたログ行の配列
- */
-export const filterLogLinesByDate = (
-  logLines: VRChatLogLine[],
-  startDate: Date,
-): VRChatLogLine[] => {
-  return logLines.filter((logLine) => {
-    // ログから日付と時刻を抽出
-    const dateTimeMatch = logLine.value.match(
-      /^(\d{4})\.(\d{2})\.(\d{2}) (\d{2}):(\d{2}):(\d{2})/,
-    );
-    if (!dateTimeMatch) return false;
-
-    const [, year, month, day, hour, minute, second] = dateTimeMatch;
-    // datefnsを使用して日付をパース - フォーマットを明示的に指定
-    const logDate = datefns.parse(
-      `${year}-${month}-${day} ${hour}:${minute}:${second}`,
-      'yyyy-MM-dd HH:mm:ss',
-      new Date(),
-    );
-
-    // 日付パースの失敗をチェック
-    if (!datefns.isValid(logDate)) {
-      return false;
-    }
-
-    // 指定された日付以降のみを含める
-    return (
-      datefns.isAfter(logDate, startDate) || datefns.isEqual(logDate, startDate)
-    );
-  });
-};
+// パーサー機能の再エクスポート
+export { extractPlayerJoinInfoFromLog, filterLogLinesByDate };

--- a/electron/module/vrchatWorldJoinLog/VRChatWorldJoinLogModel/s_model.ts
+++ b/electron/module/vrchatWorldJoinLog/VRChatWorldJoinLogModel/s_model.ts
@@ -67,9 +67,9 @@ export const createVRChatWorldJoinLog = async (
 ): Promise<VRChatWorldJoinLogModel[]> => {
   const newLogs = vrchatWorldJoinLogList.map((logInfo) => ({
     joinDateTime: logInfo.joinDate,
-    worldId: logInfo.worldId,
-    worldInstanceId: logInfo.worldInstanceId,
-    worldName: logInfo.worldName,
+    worldId: logInfo.worldId.value,
+    worldInstanceId: logInfo.worldInstanceId.value,
+    worldName: logInfo.worldName.value,
   }));
 
   if (newLogs.length > 0) {


### PR DESCRIPTION
- **refactor: VRChatログサービスを単一責任原則に従って分割し保守性を大幅改善**
- **feat: VRChatログ関連のvalueObjectsパターンを導入し型安全性を大幅向上**
- **refactor: パーサーでvalueObjectsを使用し型安全性を向上**
- **fix: データベース操作でvalueObjectsを文字列値に変換**
- **fix: extractPlayerJoinInfoFromLogのテストでvalueObjectsのプロパティにアクセスするように修正**
- **feat: settings.local.jsonに新しいBashコマンドを追加**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive parsing and validation for VRChat log files, including structured extraction of world join, player join, and player leave events.
  - Added robust value object classes and schemas for VRChat identifiers and names, improving data consistency and validation.
  - Enabled importing log data from photo directories and managing log storage with file size handling and deduplication.

- **Bug Fixes**
  - Improved normalization of player and world identifiers to handle both string and object formats, ensuring consistent data processing.

- **Refactor**
  - Modularized log parsing and file handling for better maintainability and scalability.
  - Simplified service interfaces by delegating logic to specialized modules.

- **Tests**
  - Added extensive test coverage for log parsers, value objects, and data extraction logic to ensure reliability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->