### PR TITLE
fix: log保存時のバリデーション調整、photoAsLogとの動作調整

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,7 @@
       "Bash(yarn test:*)",
       "Bash(npx tsc:*)",
       "Bash(npx vitest run:*)",
-      "Bash(grep:*)"
+      "Bash(find:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,9 @@
       "Bash(yarn test:*)",
       "Bash(npx tsc:*)",
       "Bash(npx vitest run:*)",
-      "Bash(find:*)"
+      "Bash(find:*)",
+      "mcp__ide__getDiagnostics",
+      "Bash(yarn tsc:*)"
     ],
     "deny": []
   }

--- a/debug/logs/output_log_2025-02-23_22-01-07.txt
+++ b/debug/logs/output_log_2025-02-23_22-01-07.txt
@@ -1,5 +1,5 @@
 2025.02.22 21:13:47 Debug      -  VRC Analytics Initialized
-2025.02.22 21:13:56 Debug      -  [Behaviour] Joining wrld6fecf18a-ab96-43f2-82dc-ccf79f17c34f:04307~region(jp)
+2025.02.22 21:13:56 Debug      -  [Behaviour] Joining wrld_6fecf18a-ab96-43f2-82dc-ccf79f17c34f:04307~region(jp)
 2025.02.22 21:13:56 Debug      -  [Behaviour] Joining or Creating Room: はじまりタウン ⁄ Dawnville
 2025.02.22 21:14:07 Debug      -  [Behaviour] OnPlayerJoined tkt (usr_3ba2a992-724c-4463-bc75-7e9f6674e8e0)
 2025.02.22 21:14:48 Debug      -  [Behaviour] OnPlayerLeft tkt (usr_3ba2a992-724c-4463-bc75-7e9f6674e8e0)

--- a/electron/module/logInfo/service.ts
+++ b/electron/module/logInfo/service.ts
@@ -169,22 +169,7 @@ export async function loadLogInfoIndexFromVRChatLog({
   const totalStartTime = performance.now();
   logger.info('loadLogInfoIndexFromVRChatLog start');
 
-  // 1. 写真フォルダからのログインポート
-  const importLogPhotoStartTime = performance.now();
-  const vrChatPhotoDirPath = await vrchatPhotoService.getVRChatPhotoDirPath();
-  if (vrChatPhotoDirPath) {
-    await vrchatLogService.importLogLinesFromLogPhotoDirPath({
-      vrChatPhotoDirPath,
-    });
-  }
-  const importLogPhotoEndTime = performance.now();
-  logger.debug(
-    `Import log lines from photo dir took ${
-      importLogPhotoEndTime - importLogPhotoStartTime
-    } ms`,
-  );
-
-  // 2. 処理対象となるログファイルパスを取得
+  // 1. 処理対象となるログファイルパスを取得
   const getLogPathsStartTime = performance.now();
   const logStoreFilePaths = await _getLogStoreFilePaths(excludeOldLogLoad);
   const getLogPathsEndTime = performance.now();
@@ -363,6 +348,21 @@ export async function loadLogInfoIndexFromVRChatLog({
   logger.debug(
     `Create photo path index took ${
       photoIndexEndTime - photoIndexStartTime
+    } ms`,
+  );
+
+  // 7. 写真フォルダからのログインポート（通常ログ処理後に実行）
+  const importLogPhotoStartTime = performance.now();
+  const vrChatPhotoDirPath = vrchatPhotoService.getVRChatPhotoDirPath();
+  if (vrChatPhotoDirPath) {
+    await vrchatLogService.importLogLinesFromLogPhotoDirPath({
+      vrChatPhotoDirPath,
+    });
+  }
+  const importLogPhotoEndTime = performance.now();
+  logger.debug(
+    `Import log lines from photo dir took ${
+      importLogPhotoEndTime - importLogPhotoStartTime
     } ms`,
   );
 

--- a/electron/module/vrchatLog/model.test.ts
+++ b/electron/module/vrchatLog/model.test.ts
@@ -73,15 +73,23 @@ describe('VRChatログ関連のvalueObjects', () => {
       expect(instanceId.value).toBe(validId);
     });
 
+    it('16進数のインスタンスIDでvalueObjectを作成できる', () => {
+      const validId = '83c39dd3c3~region(us)';
+      const instanceId = VRChatWorldInstanceIdSchema.parse(validId);
+      expect(instanceId.value).toBe(validId);
+    });
+
     it('無効なインスタンスIDでエラーが発生する', () => {
       expect(() => VRChatWorldInstanceIdSchema.parse('invalid-id')).toThrow();
-      expect(() => VRChatWorldInstanceIdSchema.parse('12345a')).toThrow();
+      expect(() => VRChatWorldInstanceIdSchema.parse('123@45')).toThrow();
       expect(() => VRChatWorldInstanceIdSchema.parse('')).toThrow();
     });
 
     it('isValid静的メソッドが正しく動作する', () => {
       expect(VRChatWorldInstanceId.isValid('12345')).toBe(true);
       expect(VRChatWorldInstanceId.isValid('86676~region(jp)')).toBe(true);
+      expect(VRChatWorldInstanceId.isValid('83c39dd3c3~region(us)')).toBe(true);
+      expect(VRChatWorldInstanceId.isValid('abc123')).toBe(true);
       expect(VRChatWorldInstanceId.isValid('invalid-id')).toBe(false);
     });
   });

--- a/electron/module/vrchatLog/model.ts
+++ b/electron/module/vrchatLog/model.ts
@@ -124,10 +124,10 @@ class VRChatWorldInstanceId extends BaseValueObject<
 > {
   /**
    * インスタンスIDが有効な形式かを検証
-   * 数値のみ、または数値~region(region_code)形式を許可
+   * 英数字のみ、または英数字~region(region_code)形式を許可
    */
   public static isValid(value: string): boolean {
-    return /^\d+(\~.+)?$/.test(value);
+    return /^[a-zA-Z0-9]+(\~.+)?$/.test(value);
   }
 }
 
@@ -203,10 +203,9 @@ export const VRChatWorldIdSchema = z
 
 export const VRChatWorldInstanceIdSchema = z
   .string()
-  .refine(VRChatWorldInstanceId.isValid, {
-    message:
-      'Invalid VRChat World Instance ID format. Expected: numeric string or numeric~region(region_code)',
-  })
+  .refine(VRChatWorldInstanceId.isValid, (value) => ({
+    message: `Invalid VRChat World Instance ID format. Expected: alphanumeric string or alphanumeric~region(region_code). received: ${value}`,
+  }))
   .transform((value) => new VRChatWorldInstanceId(value));
 
 export const VRChatPlayerNameSchema = z

--- a/electron/module/vrchatLog/parsers/index.ts
+++ b/electron/module/vrchatLog/parsers/index.ts
@@ -30,7 +30,7 @@ export const convertLogLinesToWorldAndPlayerJoinLogInfos = (
 
   for (const [index, l] of logLines.entries()) {
     // ワールド参加ログ
-    if (l.value.includes('Joining wrld')) {
+    if (l.value.includes('Joining wrld_')) {
       const info = extractWorldJoinInfoFromLogs(logLines, index);
       if (info) {
         logInfos.push(info);

--- a/electron/module/vrchatLog/service.test.ts
+++ b/electron/module/vrchatLog/service.test.ts
@@ -315,7 +315,7 @@ describe('filterLogLinesByDate', () => {
   test('正しくログを日付でフィルタリングする', () => {
     // テスト用のログライン
     const logLines = [
-      '2025.02.22 21:13:56 Debug      -  [Behaviour] Joining wrld6fecf18a-ab96-43f2-82dc-ccf79f17c34f:04307~region(jp)',
+      '2025.02.22 21:13:56 Debug      -  [Behaviour] Joining wrld_6fecf18a-ab96-43f2-82dc-ccf79f17c34f:04307~region(jp)',
       '2025.02.22 21:13:56 Debug      -  [Behaviour] Joining or Creating Room: はじまりタウン ⁄ Dawnville',
       '2025.02.22 21:14:07 Debug      -  [Behaviour] OnPlayerJoined tkt (usr_3ba2a992-724c-4463-bc75-7e9f6674e8e0)',
       '2025.02.22 21:14:48 Debug      -  [Behaviour] OnPlayerLeft tkt (usr_3ba2a992-724c-4463-bc75-7e9f6674e8e0)',


### PR DESCRIPTION
- #375

- **feat: VRChatWorldInstanceIdのバリデーションを強化し、テストケースを追加**
- **chore: worldId の検証を厳格化**
- **chore: settings.local.jsonのBashコマンドを更新し、"Bash(grep:*)"を"Bash(find:*)"に変更**
- **feat: 統合されたワールド参加ログの取得機能を追加**
