### PR TITLE
feat: local 開発で Sentry が dev で送られるように

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -2,6 +2,9 @@
 # DBus設定
 eval `dbus-launch --sh-syntax`
 
+# 開発環境のための環境変数設定
+export NODE_ENV=development
+
 # Viteの開発サーバーをバックグラウンドで起動
 yarn dev:vite &
 VITE_PID=$!


### PR DESCRIPTION
- Sentryの初期化時に開発環境かどうかを判定し、環境に応じた設定を適用
- 規約同意のチェックを開発環境でも行うように変更し、関連するログ出力を追加
- 開発環境でのSentryイベント送信に関するログを強化
- dev.shに開発環境用のNODE_ENV設定を追加
