### PR TITLE
fix: LocationGroupHeaderでrejoinしたプレイヤーの重複表示を防止 + docs更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,29 @@ This is an Electron desktop application for organizing VRChat photos by automati
 
 ## ⚠️ CRITICAL GUIDELINES - データ整合性必須事項
 
+### 🚨 Task Completion Requirements (品質保証必須)
+**全てのタスク完了時に必ず実行してください - 実行しないとデータ破損やビルド失敗のリスクがあります**
+
+#### 必須実行項目 (MANDATORY BEFORE TASK COMPLETION)
+- ✅ **Testing**: `yarn test` (ALL tests must pass)
+- ✅ **Linting**: `yarn lint` (no remaining issues)
+- ✅ **Type Checking**: included in lint command
+- ✅ **Auto-fix**: `yarn lint:fix` if formatting issues exist
+
+#### タスク完了プロセス (TASK COMPLETION PROCESS)
+```
+1. Code Implementation (コード実装)
+   ↓
+2. yarn lint:fix (自動修正)
+   ↓
+3. yarn lint (検証)
+   ↓
+4. yarn test (テスト実行)
+   ↓
+5. Task Completion (完了宣言)
+```
+**このプロセスを省略するとPRでCI失敗やデータ整合性問題が発生します**
+
 ### 🚨 Log Synchronization Rules (データ破損防止のため厳守)
 **違反するとVRChat写真が間違ったワールドに分類され、データ整合性が破壊されます**
 

--- a/src/v2/components/LocationGroupHeader/__tests__/LocationGroupHeader.test.tsx
+++ b/src/v2/components/LocationGroupHeader/__tests__/LocationGroupHeader.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { LocationGroupHeader } from '../index';
+
+// tRPCモック
+vi.mock('@/trpc', () => ({
+  trpcReact: {
+    vrchatApi: {
+      getVrcWorldInfoByWorldId: {
+        useQuery: vi.fn().mockReturnValue({ data: null }),
+      },
+    },
+    logInfo: {
+      getPlayerListInSameWorld: {
+        useQuery: vi.fn().mockReturnValue({ data: [], isLoading: false }),
+      },
+    },
+  },
+}));
+
+// IntersectionObserverのモック
+global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// createPortalのモック
+vi.mock('react-dom', () => ({
+  createPortal: vi.fn((element) => element),
+}));
+
+const mockProps = {
+  worldId: 'wrld_12345',
+  worldName: 'Test World',
+  worldInstanceId: 'instance123',
+  photoCount: 5,
+  joinDateTime: new Date('2023-01-01T12:00:00Z'),
+};
+
+describe('LocationGroupHeader - Player Uniqueness', () => {
+  it('rejoinしたプレイヤーの重複を除去する', () => {
+    const { trpcReact } = require('@/trpc');
+
+    // 同じプレイヤーが複数回joinしたデータをモック
+    const duplicatePlayersData = [
+      {
+        id: '1',
+        playerId: 'usr_player1',
+        playerName: 'DuplicatePlayer',
+        joinDateTime: new Date('2023-01-01T12:05:00Z'),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: '2',
+        playerId: 'usr_player2',
+        playerName: 'UniquePlayer',
+        joinDateTime: new Date('2023-01-01T12:10:00Z'),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: '3',
+        playerId: 'usr_player1',
+        playerName: 'DuplicatePlayer', // 同じプレイヤー名（rejoin）
+        joinDateTime: new Date('2023-01-01T12:15:00Z'),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    trpcReact.logInfo.getPlayerListInSameWorld.useQuery.mockReturnValue({
+      data: duplicatePlayersData,
+      isLoading: false,
+    });
+
+    render(<LocationGroupHeader {...mockProps} />);
+
+    // プレイヤー数表示が重複排除されていることを確認（3人ではなく2人）
+    expect(screen.getByText('2')).toBeTruthy();
+
+    // プレイヤー名が重複表示されていないことを確認
+    const duplicatePlayerElements = screen.getAllByText('DuplicatePlayer');
+    expect(duplicatePlayerElements).toHaveLength(1); // 1回だけ表示されるべき
+  });
+
+  it('異なるプレイヤー名は正常に表示される', () => {
+    const { trpcReact } = require('@/trpc');
+
+    const uniquePlayersData = [
+      {
+        id: '1',
+        playerId: 'usr_player1',
+        playerName: 'Player1',
+        joinDateTime: new Date('2023-01-01T12:05:00Z'),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: '2',
+        playerId: 'usr_player2',
+        playerName: 'Player2',
+        joinDateTime: new Date('2023-01-01T12:10:00Z'),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: '3',
+        playerId: 'usr_player3',
+        playerName: 'Player3',
+        joinDateTime: new Date('2023-01-01T12:15:00Z'),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    trpcReact.logInfo.getPlayerListInSameWorld.useQuery.mockReturnValue({
+      data: uniquePlayersData,
+      isLoading: false,
+    });
+
+    render(<LocationGroupHeader {...mockProps} />);
+
+    // 全プレイヤーが表示されることを確認
+    expect(screen.getByText('3')).toBeTruthy();
+    expect(screen.getByText('Player1')).toBeTruthy();
+    expect(screen.getByText('Player2')).toBeTruthy();
+    expect(screen.getByText('Player3')).toBeTruthy();
+  });
+
+  it('空のプレイヤーリストを正しく処理する', () => {
+    const { trpcReact } = require('@/trpc');
+
+    trpcReact.logInfo.getPlayerListInSameWorld.useQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+
+    render(<LocationGroupHeader {...mockProps} />);
+
+    // プレイヤーセクションが表示されないことを確認
+    expect(screen.queryByText(/\d+/)).toBeNull();
+  });
+});

--- a/src/v2/components/LocationGroupHeader/index.tsx
+++ b/src/v2/components/LocationGroupHeader/index.tsx
@@ -81,7 +81,13 @@ export const LocationGroupHeader = ({
 
   // Derived state
   const formattedDate = format(joinDateTime, 'yyyy年MM月dd日 HH:mm');
-  const players = Array.isArray(playersResult) ? playersResult : null;
+  // プレイヤーリストの重複を除去（rejoinしたプレイヤーが複数回表示されるのを防ぐ）
+  const players = Array.isArray(playersResult)
+    ? playersResult.filter(
+        (player, index, arr) =>
+          arr.findIndex((p) => p.playerName === player.playerName) === index,
+      )
+    : null;
 
   // プレイヤーリスト表示のカスタムフック
   const {


### PR DESCRIPTION
## Summary
• LocationGroupHeaderでrejoinしたプレイヤーが重複表示される問題を修正
• CLAUDE.mdにタスク完了前のテスト・lint実行必須要件を追加

## Test plan
- [x] 重複プレイヤーの除去ロジックのテストを追加
- [x] 異なるプレイヤー名の正常表示確認
- [x] 空のプレイヤーリストの処理確認
- [x] yarn lint実行済み
- [x] yarn test実行済み

🤖 Generated with [Claude Code](https://claude.ai/code)