### PR TITLE
feat: 写真の右クリックメニューからシェア機能を削除

### DIFF
--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -213,7 +213,6 @@ const GalleryContent = memo(
                     {group.photos.length > 0 && (
                       <div className="w-full rounded-b-lg overflow-hidden">
                         <PhotoGrid
-                          worldId={group.worldInfo?.worldId ?? null}
                           photos={group.photos}
                           onPhotoSelect={setSelectedPhoto}
                           selectedPhotos={selectedPhotos}

--- a/src/v2/components/PhotoGrid.tsx
+++ b/src/v2/components/PhotoGrid.tsx
@@ -11,8 +11,6 @@ import PhotoCard from './PhotoCard';
 interface PhotoGridProps {
   /** 表示する写真オブジェクトの配列 */
   photos: Photo[];
-  /** 写真が属するワールドのID (Nullable) */
-  worldId: string | null;
   /** 写真がクリックされたときに呼び出されるコールバック (モーダル表示用) */
   onPhotoSelect: (photo: Photo) => void;
   /** 現在選択されている写真のIDセット */
@@ -61,7 +59,6 @@ interface PhotoGridProps {
  */
 export default function PhotoGrid({
   photos,
-  worldId,
   onPhotoSelect,
   selectedPhotos,
   setSelectedPhotos,
@@ -103,7 +100,6 @@ export default function PhotoGrid({
                   >
                     <PhotoCard
                       photo={photo}
-                      worldId={worldId}
                       onSelect={onPhotoSelect}
                       priority={index === 0}
                       selectedPhotos={selectedPhotos}


### PR DESCRIPTION
- PhotoCardの右クリックメニューから「写真をシェア」と「シェア画像をダウンロード」を削除
- シェア関連の未使用コードとパラメータを除去
- PhotoGridとGalleryContentからworldIdパラメータを削除


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the world-related information and sharing functionality from photo cards and the photo grid.
  - Simplified the photo gallery and grid components by eliminating the world ID property and associated logic.
- **User Interface**
  - Context menu options for sharing and downloading generated share images have been removed from photo cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->