### PR TITLE
Add docstrings to undocumented functions

### DIFF
--- a/electron/electronUtil.ts
+++ b/electron/electronUtil.ts
@@ -395,6 +395,10 @@ const setTimeEventEmitter = (
 
 export { setTray, createOrGetWindow, setTimeEventEmitter };
 
+/**
+ * 他モジュールから設定ストアを利用できるよう初期化する。
+ * main プロセス起動時に一度だけ呼び出されることを想定。
+ */
 export const initializeSettingStoreForUtil = (): void => {
   if (settingStore === null) {
     settingStore = getSettingStore();

--- a/electron/lib/logger.ts
+++ b/electron/lib/logger.ts
@@ -29,12 +29,18 @@ interface ErrorLogParams {
   stack?: Error;
 }
 
-// エラーオブジェクトの正規化
+/**
+ * 受け取ったメッセージを Error オブジェクトに変換するユーティリティ。
+ * buildErrorInfo や error 関数から利用される。
+ */
 const normalizeError = (message: unknown): Error => {
   return message instanceof Error ? message : new Error(String(message));
 };
 
-// エラー情報の構築（stack traceを適切に保持）
+/**
+ * stack 情報を含めたエラーオブジェクトを生成するヘルパー。
+ * Sentry 送信前の整形処理で使用される。
+ */
 const buildErrorInfo = ({ message, stack }: ErrorLogParams): Error => {
   const baseError =
     message instanceof Error ? message : normalizeError(message);
@@ -55,6 +61,9 @@ const buildErrorInfo = ({ message, stack }: ErrorLogParams): Error => {
 const info = log.info;
 const debug = log.debug;
 const warn = log.warn;
+/**
+ * Sentry への送信も行うエラー出力用ラッパー関数。
+ */
 const error = ({ message, stack }: ErrorLogParams): void => {
   const normalizedError = normalizeError(message);
   const errorInfo = buildErrorInfo({ message, stack });

--- a/electron/lib/wrappedFs.ts
+++ b/electron/lib/wrappedFs.ts
@@ -4,6 +4,10 @@ import type { Result } from 'neverthrow';
 import { err, ok } from 'neverthrow';
 import { P, match } from 'ts-pattern';
 
+/**
+ * 同期的にファイルを読み込み、存在しない場合はエラー情報を返す。
+ * ログ処理など複数のサービスから利用される。
+ */
 export const readFileSyncSafe = (
   filePath: string,
   options?: { encoding?: null; flag?: string } | null,
@@ -34,6 +38,10 @@ export type FSError = 'ENOENT';
 
 const readdirPromisified = promisify(fs.readdir);
 type ReaddirReturn = PromiseType<ReturnType<typeof readdirPromisified>>;
+/**
+ * 非同期でディレクトリを読み込み、存在しない場合はエラーを返す。
+ * VRChat ログ検索処理などで使用される。
+ */
 export const readdirAsync = async (
   ...args: Parameters<typeof readdirPromisified>
 ): Promise<
@@ -56,6 +64,10 @@ export const readdirAsync = async (
   }
 };
 
+/**
+ * ファイルを書き込み、失敗時には Error を Result として返す同期版ヘルパー。
+ * ログ保存処理など複数箇所から利用される。
+ */
 export const writeFileSyncSafe = (
   path: string,
   data: string | Uint8Array,
@@ -70,10 +82,18 @@ export const writeFileSyncSafe = (
 
 import typeUtils from 'node:util/types';
 
+/**
+ * Node.js のエラーオブジェクトかどうかを判定するユーティリティ。
+ * ファイル操作ヘルパー群から内部的に利用される。
+ */
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return typeUtils.isNativeError(error);
 }
 
+/**
+ * ディレクトリを作成し、既に存在する場合はエラー情報を返す非同期関数。
+ * VRChat 写真保存処理などで使用される。
+ */
 export const mkdirSyncSafe = async (
   dirPath: string,
 ): Promise<Result<void, { code: 'EEXIST'; error: NodeJS.ErrnoException }>> => {
@@ -106,6 +126,10 @@ type PromiseType<T extends PromiseLike<unknown>> = T extends PromiseLike<
 
 const appendFilePromisified = promisify(fs.appendFile);
 type AppendFileReturn = PromiseType<ReturnType<typeof appendFilePromisified>>;
+/**
+ * ファイル末尾にデータを追記する非同期関数。
+ * ログファイル更新処理で利用される。
+ */
 export const appendFileAsync = async (
   ...args: Parameters<typeof appendFilePromisified>
 ): Promise<
@@ -126,7 +150,10 @@ export const appendFileAsync = async (
   }
 };
 
-// delete file
+/**
+ * 指定したファイルを削除する非同期関数。
+ * 一時ファイルのクリーンアップ処理などで使用される。
+ */
 export const unlinkAsync = async (
   path: string,
 ): Promise<Result<void, Error>> => {
@@ -138,6 +165,10 @@ export const unlinkAsync = async (
   }
 };
 
+/**
+ * fs.createReadStream をラップしたユーティリティ。
+ * 大きなファイルをストリームとして処理する際に利用される。
+ */
 export const createReadStream = (
   filePath: string,
   options?: Parameters<typeof fs.createReadStream>[1],

--- a/electron/module/backgroundSettings/controller/backgroundSettingsController.ts
+++ b/electron/module/backgroundSettings/controller/backgroundSettingsController.ts
@@ -4,6 +4,10 @@ import { UserFacingError } from './../../../lib/errors';
 import { procedure, router as trpcRouter } from './../../../trpc';
 import type { getSettingStore } from './../../settingStore';
 
+/**
+ * バックグラウンド用ファイル生成設定を取得するヘルパー。
+ * Router 内から呼び出される。
+ */
 const getIsBackgroundFileCreationEnabled =
   (settingStore: ReturnType<typeof getSettingStore>) =>
   async (): Promise<boolean> => {
@@ -12,6 +16,10 @@ const getIsBackgroundFileCreationEnabled =
     return flag ?? false;
   };
 
+/**
+ * バックグラウンド用ファイル生成設定を更新するヘルパー。
+ * Router 内から呼び出される。
+ */
 const setIsBackgroundFileCreationEnabled =
   (settingStore: ReturnType<typeof getSettingStore>) =>
   async (isEnabled: boolean) => {
@@ -22,12 +30,20 @@ const setIsBackgroundFileCreationEnabled =
     );
   };
 
+/**
+ * アプリの自動起動設定が有効かを取得するユーティリティ。
+ * SystemSettings コンポーネントから利用される。
+ */
 const getIsAppAutoStartEnabled = async (): Promise<boolean> => {
   const loginItemSettings = app.getLoginItemSettings();
   console.log('loginItemSettings', loginItemSettings);
   return loginItemSettings.openAtLogin;
 };
 
+/**
+ * アプリの自動起動設定を変更するユーティリティ。
+ * SystemSettings からの更新操作に用いられる。
+ */
 const setIsAppAutoStartEnabled = async (isEnabled: boolean) => {
   console.log('setIsAppAutoStartEnabled: before', app.getLoginItemSettings());
 

--- a/electron/module/electronUtil/service.ts
+++ b/electron/module/electronUtil/service.ts
@@ -6,6 +6,10 @@ import { app, clipboard, dialog, nativeImage, shell } from 'electron';
 import * as neverthrow from 'neverthrow';
 import sharp from 'sharp';
 
+/**
+ * OS のエクスプローラーで指定パスを開くユーティリティ。
+ * main プロセスの service モジュール各所から利用される。
+ */
 const openPathInExplorer = async (
   path: string,
 ): Promise<neverthrow.Result<string, Error>> => {
@@ -21,10 +25,18 @@ const openPathInExplorer = async (
   }
 };
 
+/**
+ * アプリケーションのログ保存ディレクトリを取得する。
+ * エラーログ閲覧メニューなどで参照される。
+ */
 export const getApplicationLogPath = (): string => {
   return app.getPath('logs');
 };
 
+/**
+ * ディレクトリ選択ダイアログを表示し、選択されたパスを返す。
+ * 設定画面からフォルダ指定する際に使用される。
+ */
 const openGetDirDialog = async (): Promise<
   neverthrow.Result<string, 'canceled'>
 > => {
@@ -37,6 +49,10 @@ const openGetDirDialog = async (): Promise<
   return neverthrow.ok(result.filePaths[0]);
 };
 
+/**
+ * ファイル/ディレクトリ選択ダイアログを表示する汎用関数。
+ * VRChat ログフォルダなどの設定入力で利用される。
+ */
 const openGetFileDialog = async (
   properties: Array<'openDirectory' | 'openFile' | 'multiSelections'>,
 ): Promise<neverthrow.Result<string[], 'canceled'>> => {
@@ -49,10 +65,18 @@ const openGetFileDialog = async (
   return neverthrow.ok(result.filePaths);
 };
 
+/**
+ * 既定のブラウザで URL を開くシンプルなヘルパー。
+ * ShareDialog などからリンクを開く際に使用される。
+ */
 const openUrlInDefaultBrowser = (url: string) => {
   return shell.openExternal(url);
 };
 
+/**
+ * 写真ファイルを OS 標準のフォトビューアで開く関数。
+ * PhotoCard の"画像で開く"操作などから利用される。
+ */
 const openPhotoPathWithPhotoApp = async (
   filePath: string,
 ): Promise<neverthrow.Result<string, Error>> => {
@@ -69,6 +93,10 @@ const openPhotoPathWithPhotoApp = async (
   }
 };
 
+/**
+ * 拡張子に関連付けられたアプリケーションでファイルを開く関数。
+ * エクスプローラーから開く機能などで利用される。
+ */
 const openPathWithAssociatedApp = async (
   filePath: string,
 ): Promise<neverthrow.Result<string, Error>> => {
@@ -86,6 +114,10 @@ const openPathWithAssociatedApp = async (
   }
 };
 
+/**
+ * 画像ファイルを読み込み、クリップボードへ転送する。
+ * ShareDialog からのコピー処理で利用される。
+ */
 const copyImageDataByPath = async (
   filePath: string,
 ): Promise<neverthrow.Result<void, Error>> => {
@@ -102,6 +134,10 @@ const copyImageDataByPath = async (
   }
 };
 
+/**
+ * Base64 形式の画像を一時保存してからクリップボードへコピーする。
+ * ShareDialog の画像コピー機能で利用される。
+ */
 const copyImageByBase64 = async (options: {
   pngBase64: string;
 }): Promise<neverthrow.Result<void, Error>> => {
@@ -125,6 +161,10 @@ const copyImageByBase64 = async (options: {
   }
 };
 
+/**
+ * Base64 画像を一時ファイル化して PNG として保存する処理。
+ * プレビュー画像のダウンロード機能から呼び出される。
+ */
 const downloadImageAsPng = async (options: {
   pngBase64: string;
   filenameWithoutExt: string;
@@ -179,6 +219,10 @@ interface SavePngFileOptions {
   filenameWithoutExt: string;
 }
 
+/**
+ * Base64 PNG を一時ファイルとして保存し、指定コールバックへパスを渡す。
+ * 画像コピーやダウンロード処理の共通部分として利用される。
+ */
 export const handlePngBase64WithCallback = async (
   options: SavePngFileOptions,
   callback: (tempPngPath: string) => Promise<void>,
@@ -211,6 +255,10 @@ export const handlePngBase64WithCallback = async (
   }
 };
 
+/**
+ * PNG ファイル保存用のダイアログを表示する。
+ * downloadImageAsPng から呼び出される。
+ */
 export const showSavePngDialog = async (filenameWithoutExt: string) => {
   return dialog.showSaveDialog({
     defaultPath: path.join(
@@ -225,6 +273,10 @@ export const showSavePngDialog = async (filenameWithoutExt: string) => {
   });
 };
 
+/**
+ * 一時ファイルから指定パスへファイルを保存する単純なヘルパー。
+ * downloadImageAsPng 内部で利用される。
+ */
 export const saveFileToPath = async (
   sourcePath: string,
   destinationPath: string,
@@ -233,6 +285,10 @@ export const saveFileToPath = async (
 };
 
 // 複数ファイルをクリップボードにコピーする (クロスプラットフォーム対応)
+/**
+ * 複数ファイルのパスをクリップボードにコピーするクロスプラットフォーム対応関数。
+ * ファイル共有機能などで利用される。
+ */
 const copyMultipleFilesToClipboard = async (
   filePaths: string[],
 ): Promise<neverthrow.Result<void, Error>> => {

--- a/electron/module/vrchatWorldJoinLogFromPhoto/service.ts
+++ b/electron/module/vrchatWorldJoinLogFromPhoto/service.ts
@@ -1,6 +1,10 @@
 import * as Model from './vrchatWorldJoinLogFromPhoto.model';
 import type { VRChatWorldJoinLogFromPhoto } from './vrchatWorldJoinLogFromPhoto.model';
 
+/**
+ * モデル層の createVRChatWorldJoinLogFromPhoto を呼び出し、
+ * 引数ログ情報を保存するサービス関数。
+ */
 export const createVRChatWorldJoinLogFromPhoto = async (
   logs: VRChatWorldJoinLogFromPhoto[],
 ) => {
@@ -14,6 +18,10 @@ export const createVRChatWorldJoinLogFromPhoto = async (
   return createdLogs;
 };
 
+/**
+ * 写真由来のワールド参加ログを取得するサービス関数。
+ * コントローラから利用され、モデルの検索結果を整形して返す。
+ */
 export const findVRChatWorldJoinLogFromPhotoList = async (query?: {
   gtJoinDateTime?: Date;
   ltJoinDateTime?: Date;

--- a/electron/module/vrchatWorldJoinLogFromPhoto/vrchatWorldJoinLogFromPhoto.model.ts
+++ b/electron/module/vrchatWorldJoinLogFromPhoto/vrchatWorldJoinLogFromPhoto.model.ts
@@ -62,6 +62,10 @@ export class VRChatWorldJoinLogFromPhotoModel extends Model<
   declare updatedAt: CreationOptional<Date>;
 }
 
+/**
+ * 写真から抽出したワールド入室情報をデータベースに保存する。
+ * サービス層から呼び出される実体モデル操作関数。
+ */
 export const createVRChatWorldJoinLogFromPhoto = async (
   vrchatWorldJoinLogFromPhotoList: VRChatWorldJoinLogFromPhoto[],
 ): Promise<VRChatWorldJoinLogFromPhotoModel[]> => {
@@ -85,6 +89,10 @@ export const createVRChatWorldJoinLogFromPhoto = async (
   return vrchatWorldJoinLog;
 };
 
+/**
+ * 保存済みの写真由来ワールド入室ログを取得するモデル関数。
+ * controller 層やテストから利用される。
+ */
 export const findVRChatWorldJoinLogFromPhotoList = async (query?: {
   gtJoinDateTime?: Date;
   ltJoinDateTime?: Date;

--- a/src/v2/contexts/ThemeContext.tsx
+++ b/src/v2/contexts/ThemeContext.tsx
@@ -12,6 +12,10 @@ export const ThemeContext = createContext<ThemeContextType | undefined>(
   undefined,
 );
 
+/**
+ * アプリ全体のテーマ状態を提供するコンテキストプロバイダー。
+ * App.tsx で使用され、useTheme フックから参照される。
+ */
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>(() => {
     return (localStorage.getItem('theme') as Theme) || 'system';

--- a/src/v2/hooks/use-toast.ts
+++ b/src/v2/hooks/use-toast.ts
@@ -58,6 +58,10 @@ interface State {
 
 const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
 
+/**
+ * 指定したトーストを一定時間後に自動削除するキューへ登録する。
+ * reducer や dispatch から呼び出される内部ユーティリティ。
+ */
 const addToRemoveQueue = (toastId: string) => {
   if (toastTimeouts.has(toastId)) {
     return;
@@ -74,6 +78,10 @@ const addToRemoveQueue = (toastId: string) => {
   toastTimeouts.set(toastId, timeout);
 };
 
+/**
+ * トースト状態を更新するリデューサー関数。
+ * アクションは内部の dispatch から送出される。
+ */
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case 'ADD_TOAST':
@@ -133,6 +141,10 @@ const listeners: Array<(state: State) => void> = [];
 
 let memoryState: State = { toasts: [] };
 
+/**
+ * reducer を実行し、登録されたリスナーへ状態変更を通知する。
+ * toast(), useToast() 内部からのみ利用される。
+ */
 function dispatch(action: Action) {
   memoryState = reducer(memoryState, action);
   for (const listener of listeners) {

--- a/src/v2/hooks/useResizeObserver.ts
+++ b/src/v2/hooks/useResizeObserver.ts
@@ -6,6 +6,11 @@ interface Size {
   height: number;
 }
 
+/**
+ * DOM 要素のサイズ変化を監視し、最新の幅と高さを返すフック。
+ * 現状このリポジトリ内では使用されていないが、
+ * コンポーネントの動的レイアウト調整に利用できる。
+ */
 export function useResizeObserver<T extends HTMLElement>(): [
   RefObject<T>,
   Size,

--- a/src/v2/i18n/store.ts
+++ b/src/v2/i18n/store.ts
@@ -12,6 +12,10 @@ interface I18nState {
   t: (key: TranslationKey) => string;
 }
 
+/**
+ * UI 文言の多言語化を実現する zustand ストア。
+ * 各コンポーネントから useI18n() で呼び出され、翻訳文字列を提供する。
+ */
 export const useI18n = create<I18nState>()(
   persist<I18nState>(
     (set, get) => ({


### PR DESCRIPTION
## Summary
- document various hooks and utilities with Japanese docstrings
- describe purpose and usage of helper functions across the project

## Testing
- `yarn lint` *(fails: RequestError: tunneling socket could not be established)*
- `yarn test` *(fails: fetch failed while running tests)*

------
https://chatgpt.com/codex/tasks/task_e_6848eb8ce5e883289f7f8cd9dcc18773