### PR TITLE
Add Japanese docstrings for various components

### DIFF
--- a/electron/lib/sequelize.ts
+++ b/electron/lib/sequelize.ts
@@ -18,6 +18,10 @@ let migrationProgeress = false;
 type SequelizeOptions = ConstructorParameters<typeof Sequelize>[0] & {
   storage: string;
 };
+/**
+ * Sequelize クライアントを生成する内部関数。
+ * 返り値は接続情報を保持したオブジェクト。
+ */
 const _newRDBClient = (props: { db_url: string }) => {
   const sequelizeOptions: SequelizeOptions = {
     dialect: SqliteDialect,
@@ -43,12 +47,20 @@ const _newRDBClient = (props: { db_url: string }) => {
   };
 };
 
+/**
+ * 外部から呼び出される初期化関数。
+ * `_initRDBClient` をラップしている。
+ */
 export const initRDBClient = (props: { db_url: string }) => {
   return _initRDBClient({
     db_url: props.db_url,
   });
 };
 
+/**
+ * グローバルな `rdbClient` を初期化する内部関数。
+ * 既に初期化されている場合はエラーを投げる。
+ */
 const _initRDBClient = (props: { db_url: string }) => {
   if (rdbClient !== null) {
     if (rdbClient.__db_url !== props.db_url) {
@@ -80,6 +92,9 @@ export const __initTestRDBClient = () => {
     db_url: dbPath,
   });
 };
+/**
+ * テスト用に生成した RDBClient を破棄しリセットする。
+ */
 export const __cleanupTestRDBClient = async () => {
   if (rdbClient === null) {
     return;
@@ -88,6 +103,10 @@ export const __cleanupTestRDBClient = async () => {
   rdbClient = null;
 };
 
+/**
+ * 初期化済みの RDBClient を取得する。
+ * 未初期化の場合は例外を送出する。
+ */
 export const getRDBClient = () => {
   if (rdbClient === null) {
     throw new Error('rdbClient is not initialized');
@@ -96,6 +115,10 @@ export const getRDBClient = () => {
 };
 
 // 共通の sync 処理を抽出した関数
+/**
+ * Sequelize の sync を実行する共通処理。
+ * マイグレーション情報の記録も行う。
+ */
 const executeSyncRDB = async (options: { force: boolean }) => {
   // 実行中は何もしない
   if (migrationProgeress) {
@@ -124,6 +147,9 @@ const executeSyncRDB = async (options: { force: boolean }) => {
   }
 };
 
+/**
+ * 必要に応じてデータベースを同期するラッパー関数。
+ */
 export const syncRDBClient = async (options?: { checkRequired: boolean }) => {
   // デフォルトは確認してから実行
   const checkRequired = options?.checkRequired ?? true;
@@ -180,6 +206,9 @@ export const checkMigrationRDBClient = async (appVersion: string) => {
   return true;
 };
 
+/**
+ * `Migrations` テーブルが存在するか確認する内部関数。
+ */
 const isExistsMigrationTable = async () => {
   try {
     await Migrations.findAll();

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -16,6 +16,10 @@ const ContextMenuSub = ContextMenuPrimitive.Sub;
 
 const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
 
+/**
+ * コンテキストメニューのサブメニューを開くトリガー。
+ * ContextMenu 内部でサブ階層を表示するときに利用される。
+ */
 const ContextMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
@@ -37,6 +41,10 @@ const ContextMenuSubTrigger = React.forwardRef<
 ));
 ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
 
+/**
+ * サブメニューの内容を表示するコンテナ。
+ * ContextMenuSubTrigger から表示される要素として利用される。
+ */
 const ContextMenuSubContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
@@ -52,6 +60,10 @@ const ContextMenuSubContent = React.forwardRef<
 ));
 ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
 
+/**
+ * コンテキストメニュー本体の内容を包むコンテナ。
+ * ContextMenuTrigger から開かれるメニューの中身に相当する。
+ */
 const ContextMenuContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
@@ -69,6 +81,10 @@ const ContextMenuContent = React.forwardRef<
 ));
 ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
 
+/**
+ * 一般的なメニュー項目を表すコンポーネント。
+ * クリック時に指定されたアクションを実行する。
+ */
 const ContextMenuItem = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
@@ -87,6 +103,10 @@ const ContextMenuItem = React.forwardRef<
 ));
 ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
 
+/**
+ * チェックボックス付きのメニュー項目。
+ * ON/OFF 設定などに使用される。
+ */
 const ContextMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
@@ -111,6 +131,10 @@ const ContextMenuCheckboxItem = React.forwardRef<
 ContextMenuCheckboxItem.displayName =
   ContextMenuPrimitive.CheckboxItem.displayName;
 
+/**
+ * ラジオボタン形式のメニュー項目。
+ * 同一グループ内で排他的に選択される。
+ */
 const ContextMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
@@ -133,6 +157,9 @@ const ContextMenuRadioItem = React.forwardRef<
 ));
 ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
 
+/**
+ * メニュー内の区切り見出しとして利用するラベル。
+ */
 const ContextMenuLabel = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
@@ -151,6 +178,9 @@ const ContextMenuLabel = React.forwardRef<
 ));
 ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName;
 
+/**
+ * メニュー項目の間に挿入する区切り線。
+ */
 const ContextMenuSeparator = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
@@ -163,6 +193,10 @@ const ContextMenuSeparator = React.forwardRef<
 ));
 ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
 
+/**
+ * キーボードショートカット表示用のスパン要素。
+ * メニュー右端に小さく描画される。
+ */
 const ContextMenuShortcut = ({
   className,
   ...props

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -12,6 +12,10 @@ const DialogPortal = DialogPrimitive.Portal;
 
 const DialogClose = DialogPrimitive.Close;
 
+/**
+ * ダイアログ表示時に背面を覆うオーバーレイ。
+ * モーダルを際立たせるために使用される。
+ */
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
@@ -27,6 +31,10 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+/**
+ * ダイアログ本体の内容を包むコンテナ。
+ * DialogOverlay と共に Portal 内でレンダリングされる。
+ */
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
@@ -51,6 +59,10 @@ const DialogContent = React.forwardRef<
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
+/**
+ * ダイアログ上部のヘッダー要素。
+ * タイトルなどを配置するためのコンテナ。
+ */
 const DialogHeader = ({
   className,
   ...props
@@ -65,6 +77,10 @@ const DialogHeader = ({
 );
 DialogHeader.displayName = 'DialogHeader';
 
+/**
+ * ダイアログ下部のフッター要素。
+ * 操作ボタンをまとめて配置する。
+ */
 const DialogFooter = ({
   className,
   ...props
@@ -79,6 +95,9 @@ const DialogFooter = ({
 );
 DialogFooter.displayName = 'DialogFooter';
 
+/**
+ * ダイアログのタイトルを表示するコンポーネント。
+ */
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
@@ -94,6 +113,9 @@ const DialogTitle = React.forwardRef<
 ));
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
+/**
+ * ダイアログ内で補足説明を表示するコンポーネント。
+ */
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -10,6 +10,10 @@ const SelectGroup = SelectPrimitive.Group;
 
 const SelectValue = SelectPrimitive.Value;
 
+/**
+ * ドロップダウンを開くためのトリガーボタン。
+ * フォームなどで選択肢を切り替える際に使用する。
+ */
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
@@ -30,6 +34,9 @@ const SelectTrigger = React.forwardRef<
 ));
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
+/**
+ * セレクトメニュー内で上方向にスクロールするボタン。
+ */
 const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
@@ -47,6 +54,9 @@ const SelectScrollUpButton = React.forwardRef<
 ));
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
+/**
+ * セレクトメニュー内で下方向にスクロールするボタン。
+ */
 const SelectScrollDownButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
@@ -65,6 +75,10 @@ const SelectScrollDownButton = React.forwardRef<
 SelectScrollDownButton.displayName =
   SelectPrimitive.ScrollDownButton.displayName;
 
+/**
+ * 選択肢一覧を表示するコンテナ。
+ * Portal 内でスクロール可能に描画される。
+ */
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
@@ -97,6 +111,9 @@ const SelectContent = React.forwardRef<
 ));
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
+/**
+ * 選択肢グループのラベル表示に利用する。
+ */
 const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
@@ -109,6 +126,10 @@ const SelectLabel = React.forwardRef<
 ));
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
+/**
+ * 個々の選択肢を表すアイテム。
+ * 選択すると値が変更される。
+ */
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
@@ -132,6 +153,9 @@ const SelectItem = React.forwardRef<
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
+/**
+ * 選択肢間の区切り線を表示するコンポーネント。
+ */
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -5,6 +5,10 @@ import * as React from 'react';
 
 import { cn } from '../lib/utils';
 
+/**
+ * UI 内で水平・垂直の区切り線を描画するコンポーネント。
+ * メニューやダイアログの中で項目を分ける際に使用する。
+ */
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -3,6 +3,10 @@ import * as React from 'react';
 
 import { cn } from '../lib/utils';
 
+/**
+ * ON/OFF を切り替えるトグルスイッチ。
+ * 設定画面などで使用される基本コンポーネント。
+ */
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -7,6 +7,10 @@ import { cn } from '@/components/lib/utils';
 
 const ToastProvider = ToastPrimitives.Provider;
 
+/**
+ * Toast を表示するためのビューポート。
+ * Toaster コンポーネントから参照される。
+ */
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
@@ -38,6 +42,9 @@ const toastVariants = cva(
   },
 );
 
+/**
+ * 単一のトースト通知を表すコンポーネント。
+ */
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
@@ -53,6 +60,9 @@ const Toast = React.forwardRef<
 });
 Toast.displayName = ToastPrimitives.Root.displayName;
 
+/**
+ * トースト内で使用するアクションボタン。
+ */
 const ToastAction = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Action>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
@@ -68,6 +78,9 @@ const ToastAction = React.forwardRef<
 ));
 ToastAction.displayName = ToastPrimitives.Action.displayName;
 
+/**
+ * トーストを閉じるためのボタン。
+ */
 const ToastClose = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Close>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
@@ -86,6 +99,9 @@ const ToastClose = React.forwardRef<
 ));
 ToastClose.displayName = ToastPrimitives.Close.displayName;
 
+/**
+ * トーストのタイトル部分を表示するコンポーネント。
+ */
 const ToastTitle = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Title>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
@@ -98,6 +114,9 @@ const ToastTitle = React.forwardRef<
 ));
 ToastTitle.displayName = ToastPrimitives.Title.displayName;
 
+/**
+ * トーストの説明文部分を表示するコンポーネント。
+ */
 const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>

--- a/src/v2/components/TermsModal.tsx
+++ b/src/v2/components/TermsModal.tsx
@@ -18,6 +18,10 @@ import { ScrollArea } from '../../components/ui/scroll-area';
 import { terms as jaTerms } from '../constants/terms/ja';
 import { useI18n } from '../i18n/store';
 
+/**
+ * 規約表示用ダイアログの本体コンポーネント。
+ * 閉じるボタンの表示を制御できる。
+ */
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
@@ -53,6 +57,10 @@ interface TermsModalProps {
   canClose?: boolean;
 }
 
+/**
+ * 利用規約とプライバシーポリシーを提示するモーダル。
+ * アプリ初回起動時や更新時に表示される。
+ */
 export const TermsModal = ({
   open,
   onAccept,


### PR DESCRIPTION
## Summary
- document UI context menu components
- document UI dialog, select, separator, switch and toast components
- document TermsModal components
- document database helper functions

## Testing
- `yarn lint`
- `yarn test` *(fails: FetchError due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6849012bf82c8328a3a3b6394702351b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added detailed JSDoc-style comments (including Japanese descriptions) to various UI components such as context menus, dialogs, select elements, separators, switches, toasts, and the terms modal, clarifying their purpose and usage.
  - Enhanced documentation for internal database-related functions, improving clarity on their roles and behaviors.
  - No changes to component functionality, structure, or exported APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->