### PR TITLE
Add Japanese docstrings for uncovered functions

### DIFF
--- a/electron/api.ts
+++ b/electron/api.ts
@@ -45,6 +45,11 @@ export const router = trpcRouter({
   updater: updaterRouter,
   subscribeToast: procedure.subscription(() => {
     return observable((emit) => {
+      /**
+       * メインプロセスの `toast` イベントを受け取り
+       * サブスクライバーへ文字列を送信する内部関数。
+       * subscribeToast の Observable 内でのみ使用される。
+       */
       function onToast(text: string) {
         emit.next(text);
       }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -19,6 +19,10 @@ interface RendererGlobalElectronTRPC {
 
 const ELECTRON_TRPC_CHANNEL = 'electron-trpc';
 
+/**
+ * tRPC 用の IPC チャンネルをレンダラに公開するヘルパー。
+ * preload スクリプトの `loaded` イベントで呼び出される。
+ */
 const exposeElectronTRPC = () => {
   const electronTRPC: RendererGlobalElectronTRPC = {
     sendMessage: (operation) =>

--- a/src/trpcWrapper.tsx
+++ b/src/trpcWrapper.tsx
@@ -13,6 +13,11 @@ import { trpcReact } from './trpc';
  * `App.tsx` のルートで使用され、API 通信とキャッシュ管理を行う環境を整える。
  */
 export default ({ children }: { children: React.ReactNode }) => {
+  /**
+   * tRPC や React Query のエラーをメインプロセスへ送り
+   * ユーザーへトースト表示するための共通ハンドラー。
+   * QueryClient の onError から呼び出される。
+   */
   const handleError = (error: Error) => {
     window.Main.sendErrorMessage(
       `Error caught by TrpcWrapper: ${error.toString()}. Stack trace: ${

--- a/src/v2/App.tsx
+++ b/src/v2/App.tsx
@@ -102,6 +102,10 @@ function AppContent() {
     });
 
   useEffect(() => {
+    /**
+     * 規約同意状況を確認した上で Sentry を初期化する内部処理。
+     * termsStatus が取得できたタイミングで useEffect から呼ばれる。
+     */
     const checkTermsAndInitializeSentry = async () => {
       if (!termsStatus) return; // termsStatusが取得できるまで待つ
 
@@ -131,6 +135,10 @@ function AppContent() {
     checkTermsAndInitializeSentry();
   }, [termsStatus, initializeSentryMain]); // initializeSentryMain と termsStatus を依存配列に含める
 
+  /**
+   * 規約同意ボタン押下時に呼び出され、
+   * 同意状態を保存して Sentry 初期化を完了させる。
+   */
   const handleTermsAccept = async () => {
     await setTermsAccepted({
       accepted: true,

--- a/src/v2/components/BoldPreview.test.tsx
+++ b/src/v2/components/BoldPreview.test.tsx
@@ -20,6 +20,10 @@ afterAll(() => {
 });
 
 describe('BoldPreviewSvg', () => {
+  /**
+   * 指定数分のモックプレイヤー配列を生成するヘルパー。
+   * 各テストケースでプレイヤーリストを用意する際に利用する。
+   */
   const generatePlayers = (count: number) => {
     return Array.from({ length: count }, (_, i) => ({
       id: `id-${i}`,

--- a/src/v2/components/LocationGroupHeader/__tests__/PlayerList.test.tsx
+++ b/src/v2/components/LocationGroupHeader/__tests__/PlayerList.test.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { type Player, PlayerList } from '../PlayerList';
 
+/**
+ * PlayerList コンポーネントのテスト用に
+ * シンプルなプレイヤーオブジェクトを生成するヘルパー。
+ */
 const createMockPlayer = (name: string, id: string): Player => ({
   id,
   playerId: `usr_${id}`,

--- a/src/v2/components/PhotoGallery/__tests__/useGroupPhotos.test.ts
+++ b/src/v2/components/PhotoGallery/__tests__/useGroupPhotos.test.ts
@@ -4,6 +4,10 @@ import { groupPhotosBySession } from '../useGroupPhotos';
 import type { WorldJoinLog } from '../useGroupPhotos';
 
 // モックデータの作成ヘルパー
+/**
+ * 指定日時の写真オブジェクトを生成するテスト用関数。
+ * groupPhotosBySession の検証で写真一覧を作る際に使用する。
+ */
 const createPhoto = (id: string | number, takenAt: Date): Photo => ({
   id: id.toString(),
   url: `photo-${id}`,
@@ -19,6 +23,10 @@ const createPhoto = (id: string | number, takenAt: Date): Photo => ({
   },
 });
 
+/**
+ * ワールド参加ログのモックを生成するヘルパー。
+ * 参加日時やワールド名を指定してテストデータを作成する。
+ */
 const createWorldJoinLog = (
   id: string | number,
   joinDateTime: Date,

--- a/src/v2/components/PhotoGallery/__tests__/usePhotoGallery.test.ts
+++ b/src/v2/components/PhotoGallery/__tests__/usePhotoGallery.test.ts
@@ -38,15 +38,27 @@ const mockPhotos = [
 type MockPhotoType = (typeof mockPhotos)[number];
 
 // モックの設定
+/**
+ * テスト用の状態管理オブジェクトを生成するヘルパー関数。
+ * setState と getState を通じて疑似的なクエリ結果を制御する。
+ */
 const createMockState = () => {
   let isLoading = true;
   let photoData: MockPhotoType[] | undefined = undefined;
 
+  /**
+   * モックの読み込み状態とデータを更新する補助関数。
+   * 各テストケースから状態変更をシミュレートするために利用する。
+   */
   const setState = (loading: boolean, data: typeof photoData) => {
     isLoading = loading;
     photoData = data;
   };
 
+  /**
+   * useQuery の戻り値を模したオブジェクトを返す関数。
+   * renderHook 内で現在のモック状態を参照するのに使用する。
+   */
   const getState = () => ({
     data: photoData,
     isLoading,

--- a/src/v2/components/settings/SqliteConsole.tsx
+++ b/src/v2/components/settings/SqliteConsole.tsx
@@ -65,6 +65,10 @@ const SqliteConsole: React.FC<SqliteConsoleProps> = ({ isOpen, onClose }) => {
     },
   ];
 
+  /**
+   * 入力されたSQLクエリを実行して結果を表示するハンドラー。
+   * 実行ボタンやショートカットキーから呼び出される。
+   */
   const handleExecute = async () => {
     if (!query.trim()) return;
 
@@ -76,6 +80,9 @@ const SqliteConsole: React.FC<SqliteConsoleProps> = ({ isOpen, onClose }) => {
     }
   };
 
+  /**
+   * テキストエリアで Cmd/Ctrl+Enter を押した際にクエリを実行する。
+   */
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();
@@ -83,12 +90,18 @@ const SqliteConsole: React.FC<SqliteConsoleProps> = ({ isOpen, onClose }) => {
     }
   };
 
+  /**
+   * デバッグログ出力の有無を切り替えるチェックボックス用ハンドラー。
+   */
   const handleDebugLogChange = (checked: boolean | 'indeterminate') => {
     const newLevel = checked ? 'debug' : 'info';
     setIsDebugLogEnabled(Boolean(checked));
     setLogLevel({ level: newLevel });
   };
 
+  /**
+   * Sentry 連携をテストするため意図的にエラーを投げる関数。
+   */
   const handleThrowError = async () => {
     try {
       await throwErrorForSentryTest();

--- a/src/v2/hooks/__tests__/useContainerWidth.test.tsx
+++ b/src/v2/hooks/__tests__/useContainerWidth.test.tsx
@@ -54,6 +54,10 @@ class MockResizeObserver {
 global.ResizeObserver = MockResizeObserver as typeof ResizeObserver;
 
 // テスト用コンポーネント
+/**
+ * useContainerWidth フックの挙動を検証するための簡易コンポーネント。
+ * 各テストケースからレンダリングされる。
+ */
 function TestComponent({ debounceMs }: { debounceMs?: number }) {
   const { containerRef, containerWidth } = useContainerWidth(debounceMs);
 
@@ -127,6 +131,10 @@ describe('useContainerWidth', () => {
   });
 
   it('containerRef が null の場合はエラーが発生しない', () => {
+    /**
+     * ref を保持しない特殊ケース用のテストコンポーネント。
+     * containerRef が null の状況を再現するために使用する。
+     */
     function TestComponentWithNullRef() {
       const { containerWidth } = useContainerWidth();
 

--- a/src/v2/utils/__tests__/justifiedLayoutCalculator.test.ts
+++ b/src/v2/utils/__tests__/justifiedLayoutCalculator.test.ts
@@ -10,6 +10,10 @@ describe('JustifiedLayoutCalculator', () => {
     calculator = new JustifiedLayoutCalculator();
   });
 
+  /**
+   * 指定数のダミー写真データを生成するユーティリティ。
+   * レイアウト計算のテストで一括生成に利用する。
+   */
   const createMockPhotos = (count: number): Photo[] =>
     Array.from({ length: count }, (_, i) => ({
       id: `photo-${i}`,


### PR DESCRIPTION
## Summary
- document internal toast subscription helper
- exposeElectronTRPC helper documentation
- add docstrings for shared error handler and startup helpers
- document various helper functions in tests and dev components
- document SQL console handler functions

## Testing
- `yarn lint`
- `yarn test` *(fails: fetch ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68490fff230c8328a82534f7723e26ef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added detailed JSDoc comments to various functions and helper utilities across the application and test files to improve code documentation and clarity for developers.
  - No changes were made to application functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->