### PR TITLE
Add Japanese docstrings

### DIFF
--- a/electron/lib/getData.ts
+++ b/electron/lib/getData.ts
@@ -40,7 +40,10 @@ export class FetchError extends Error {
   }
 }
 
-// fetchWithResult 関数
+/**
+ * ofetch を利用して HTTP リクエストを行うユーティリティ
+ * getData からのみ呼ばれ、成功可否を Result 型で返す
+ */
 const fetchWithResult = async <T = unknown>(
   url: string,
   options?: RequestInit & { query?: QueryObject },
@@ -74,7 +77,10 @@ const fetchWithResult = async <T = unknown>(
   }
 };
 
-// getData 関数の実装
+/**
+ * fetchWithResult のラッパー関数
+ * API サービス層から共通利用される
+ */
 export const getData = async <T>(
   url: string,
   options?: RequestInit & { query?: QueryObject },

--- a/electron/lib/wrappedFs.ts
+++ b/electron/lib/wrappedFs.ts
@@ -114,6 +114,10 @@ export const mkdirSyncSafe = async (
   }
 };
 
+/**
+ * fs.existsSync の薄いラッパー
+ * ログ保存処理などでファイルの存在確認に利用される
+ */
 export const existsSyncSafe = (path: string): boolean => {
   return fs.existsSync(path);
 };

--- a/electron/module/VRChatPlayerJoinLogModel/playerJoinInfoLog.model.ts
+++ b/electron/module/VRChatPlayerJoinLogModel/playerJoinInfoLog.model.ts
@@ -59,6 +59,10 @@ export class VRChatPlayerJoinLogModel extends Model<
   declare updatedAt: CreationOptional<Date>;
 }
 
+/**
+ * 重複を除外しつつプレイヤー参加ログを一括登録する
+ * サービス層の createVRChatPlayerJoinLogModel から利用される
+ */
 export const createVRChatPlayerJoinLog = async (
   playerJoinLogList: VRChatPlayerJoinLog[],
 ): Promise<VRChatPlayerJoinLogModel[]> => {
@@ -144,6 +148,10 @@ export const getVRChatPlayerJoinLogListByJoinDateTime = async (
   return playerJoinLogList;
 };
 
+/**
+ * 最後に検出されたプレイヤー参加ログを取得する
+ * ログ同期の進捗確認に使用される
+ */
 export const findLatestPlayerJoinLog = async () => {
   return VRChatPlayerJoinLogModel.findOne({
     order: [['joinDateTime', 'DESC']],

--- a/electron/module/backGroundUsecase.ts
+++ b/electron/module/backGroundUsecase.ts
@@ -1,5 +1,9 @@
 import type { getSettingStore } from './settingStore';
 
+/**
+ * 設定ストアからバックグラウンド処理の有効可否を取得する
+ * Electron 起動時や終了時判定で利用される
+ */
 const getIsEnabledBackgroundProcess =
   (settingStore: ReturnType<typeof getSettingStore>) => () => {
     const backgroundFileCreateFlag = settingStore.getBackgroundFileCreateFlag();
@@ -10,6 +14,10 @@ const getIsEnabledBackgroundProcess =
     return backgroundFileCreateFlag;
   };
 
+/**
+ * バックグラウンド関連のユースケースオブジェクトを生成する
+ * index.ts から参照される
+ */
 const getBackgroundUsecase = (
   settingStore: ReturnType<typeof getSettingStore>,
 ) => {

--- a/electron/module/vrchatApi/service.ts
+++ b/electron/module/vrchatApi/service.ts
@@ -92,6 +92,10 @@ const VRChatWorldInfoFromApiSchema = z.object({
   created_at: z.string(),
   updated_at: z.string(),
 });
+/**
+ * VRChat API からワールド情報を取得する
+ * ワールドプレビュー生成などで使用される
+ */
 export const getVrcWorldInfoByWorldId = async (
   worldId: VRChatWorldId,
 ): Promise<
@@ -140,7 +144,10 @@ const UsersSchema = z.array(UserSchema);
 
 const requestQueue: (() => Promise<void>)[] = [];
 let isProcessingQueue = false;
-
+/**
+ * API へのリクエストを順番に処理するための内部キュー
+ * 連続リクエストによる制限回避目的で getVrcUserInfoByUserName から使用
+ */
 const processQueue = async () => {
   if (isProcessingQueue) return;
   isProcessingQueue = true;
@@ -156,7 +163,8 @@ const processQueue = async () => {
 };
 
 /**
- * Auth してからじゃないと使えなさそう
+ * ユーザー名からVRChatユーザー情報を取得する
+ * 非公開APIのため一定間隔で processQueue 経由でリクエストされる
  */
 export const getVrcUserInfoByUserName = async (
   userName: string,

--- a/electron/module/vrchatApi/valueObject.ts
+++ b/electron/module/vrchatApi/valueObject.ts
@@ -10,7 +10,10 @@ export abstract class BaseValueObject<T extends string, K> {
   constructor(value: K) {
     this.value = value;
   }
-
+  /**
+   * 値オブジェクト同士の等価性を比較する
+   * API 関連の値検証で使用される
+   */
   equals(other: BaseValueObject<T, K>): boolean {
     return this === other || this.value === other.value;
   }

--- a/electron/module/vrchatLog/model.ts
+++ b/electron/module/vrchatLog/model.ts
@@ -12,7 +12,10 @@ export abstract class BaseValueObject<T extends string, K> {
   constructor(value: K) {
     this.value = value;
   }
-
+  /**
+   * 値オブジェクト同士の等価性を比較する
+   * ログ解析処理で識別子比較に使用される
+   */
   equals(other: BaseValueObject<T, K>): boolean {
     return this === other || this.value === other.value;
   }

--- a/electron/module/vrchatLogFileDir/model.ts
+++ b/electron/module/vrchatLogFileDir/model.ts
@@ -10,7 +10,10 @@ export abstract class BaseValueObject<T extends string, K> {
   constructor(value: K) {
     this.value = value;
   }
-
+  /**
+   * 値オブジェクト同士の等価性を比較する
+   * 主に設定値の比較処理で利用される
+   */
   equals(other: BaseValueObject<T, K>): boolean {
     return this === other || this.value === other.value;
   }

--- a/electron/module/vrchatLogFileDir/service.ts
+++ b/electron/module/vrchatLogFileDir/service.ts
@@ -14,6 +14,10 @@ import {
   VRChatLogFilesDirPathSchema,
 } from './model';
 
+/**
+ * 設定ストアに保存されているログディレクトリパスを取得する
+ * getValidVRChatLogFileDir から呼び出される内部処理
+ */
 const getStoredVRChatLogFilesDirPath =
   async (): Promise<NotValidatedVRChatLogFilesDirPath | null> => {
     const settingStore = getSettingStore();
@@ -27,6 +31,10 @@ const getStoredVRChatLogFilesDirPath =
       .exhaustive();
   };
 
+/**
+ * 実際に存在するVRChatログディレクトリを検証して返す
+ * getVRChatLogFileDir でエラーハンドリング付きの結果を生成するために使用
+ */
 export const getValidVRChatLogFileDir = async (): Promise<
   neverthrow.Result<
     {
@@ -73,6 +81,10 @@ export const getValidVRChatLogFileDir = async (): Promise<
   });
 };
 
+/**
+ * ログディレクトリ検証結果をシンプルなオブジェクトに整形して返す
+ * 設定画面や初期化処理から直接呼び出される
+ */
 export const getVRChatLogFileDir = async (): Promise<{
   storedPath: NotValidatedVRChatLogFilesDirPath | null;
   path: NotValidatedVRChatLogFilesDirPath | VRChatLogFilesDirPath;
@@ -93,6 +105,10 @@ export const getVRChatLogFileDir = async (): Promise<{
   };
 };
 
+/**
+ * OSごとのデフォルトVRChatログフォルダを返す
+ * getValidVRChatLogFileDir のフォールバックとして利用
+ */
 const getDefaultVRChatVRChatLogFilesDir =
   (): NotValidatedVRChatLogFilesDirPath => {
     let VRChatlogFilesDir = '';

--- a/electron/module/vrchatPhoto/valueObjects.ts
+++ b/electron/module/vrchatPhoto/valueObjects.ts
@@ -10,7 +10,10 @@ export abstract class BaseValueObject<T extends string, K> {
   constructor(value: K) {
     this.value = value;
   }
-
+  /**
+   * 値オブジェクト同士の等価性を比較する
+   * 写真保存処理で同一パス判定に使用される
+   */
   equals(other: BaseValueObject<T, K>): boolean {
     return this === other || this.value === other.value;
   }

--- a/electron/trpc.ts
+++ b/electron/trpc.ts
@@ -42,6 +42,10 @@ const t = initTRPC.context<{ eventEmitter: EventEmitter }>().create({
   },
 });
 
+/**
+ * tRPC ミドルウェアから呼び出されるエラーログ用関数
+ * バージョン情報とリクエスト内容を付加して Sentry へ送信する
+ */
 const logError = (
   err: Error | string,
   requestInfo?: string,

--- a/electron/valueObjects/index.ts
+++ b/electron/valueObjects/index.ts
@@ -11,7 +11,10 @@ export abstract class BaseValueObject<T extends string, K> {
   constructor(value: K) {
     this.value = value;
   }
-
+  /**
+   * 値オブジェクト同士の等価性を比較する
+   * 他のモジュールで value プロパティの比較に利用される
+   */
   equals(other: BaseValueObject<T, K>): boolean {
     return this === other || this.value === other.value;
   }

--- a/src/valueObjects/index.ts
+++ b/src/valueObjects/index.ts
@@ -11,7 +11,10 @@ export abstract class BaseValueObject<T extends string, K> {
   constructor(value: K) {
     this.value = value;
   }
-
+  /**
+   * 値オブジェクト同士の等価性を比較する
+   * React 側の値検証で利用される
+   */
   equals(other: BaseValueObject<T, K>): boolean {
     return this === other || this.value === other.value;
   }


### PR DESCRIPTION
## Summary
- document value object equality methods
- explain background-usecase helpers
- detail VRChat log directory helpers
- add docstrings for API helpers and error logging
- document file system utilities and join log model functions

## Testing
- `yarn lint`
- `yarn test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68492846d67c8328a1ece8db60ea382a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new utility function for safely checking file or directory existence.

- **Documentation**
	- Enhanced codebase with detailed comments explaining the purpose and usage of various functions and methods throughout the application, improving code readability and maintainability for future development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->