### PR TITLE
fix: add missing SENTRY_RELEASE environment variable in GitHub Actions

### DIFF
--- a/.github/workflows/upload-build-files.yml
+++ b/.github/workflows/upload-build-files.yml
@@ -90,6 +90,7 @@ jobs:
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
       SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      SENTRY_RELEASE: ${{ github.sha }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Set SENTRY_RELEASE to git SHA for consistent release tracking between
build process and sourcemap uploads. This fixes the "Unbound variable"
error during sentry:sourcemaps execution.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build process to include release identification for improved error tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->