### PR TITLE
Fix search overlay clearing

### DIFF
--- a/src/v2/components/SearchOverlay.tsx
+++ b/src/v2/components/SearchOverlay.tsx
@@ -152,7 +152,7 @@ const SearchOverlay = memo(
             e.preventDefault();
             if (suggestions[highlightedIndex]) {
               handleSelect(suggestions[highlightedIndex].value);
-            } else if (query.trim()) {
+            } else {
               handleSearch();
             }
             break;
@@ -176,28 +176,29 @@ const SearchOverlay = memo(
 
     // 直接検索
     const handleSearch = useCallback(() => {
-      if (query.trim()) {
-        onSearch(query.trim());
-        onClose();
-      }
+      onSearch(query.trim());
+      onClose();
     }, [query, onSearch, onClose]);
+
+    // モーダルを閉じる
+    const handleClose = useCallback(() => {
+      if (!query.trim()) {
+        onSearch('');
+      }
+      setQuery('');
+      setHighlightedIndex(0);
+      onClose();
+    }, [query, onClose, onSearch]);
 
     // モーダル外クリックで閉じる
     const handleBackdropClick = useCallback(
       (e: React.MouseEvent) => {
         if (e.target === e.currentTarget) {
-          onClose();
+          handleClose();
         }
       },
-      [onClose],
+      [handleClose],
     );
-
-    // モーダルを閉じる
-    const handleClose = useCallback(() => {
-      setQuery('');
-      setHighlightedIndex(0);
-      onClose();
-    }, [onClose]);
 
     // フォーカス管理
     useEffect(() => {


### PR DESCRIPTION
## Summary
- handle closing of search overlay to clear search
- allow submitting empty search queries

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684be210c8c88328a66405257c983623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search overlay now consistently clears the search field and resets suggestions when closed.
  - Closing the search overlay with an empty query will automatically trigger a search for all results.

- **Improvements**
  - Search is now always performed when pressing Enter, even if the search field is empty.
  - Enhanced behavior for closing the search overlay via backdrop click or Escape key, ensuring search state is reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->