### PR TITLE
fix: remove session duration limits and optimize query performance

### DIFF
--- a/electron/module/logInfo/logInfoCointroller.ts
+++ b/electron/module/logInfo/logInfoCointroller.ts
@@ -333,15 +333,12 @@ const getPlayerJoinListInSameWorldCore = async (
       worldJoinLog.joinDateTime,
     );
 
-    // デフォルト7日間ではなく、1日間に制限
-    const endDateTime =
-      nextWorldJoin?.joinDateTime ??
-      new Date(worldJoinLog.joinDateTime.getTime() + 24 * 60 * 60 * 1000);
+    const endDateTime = nextWorldJoin?.joinDateTime;
 
     logger.debug({
       message: 'Query time range determined',
       startDateTime: worldJoinLog.joinDateTime.toISOString(),
-      endDateTime: endDateTime.toISOString(),
+      endDateTime: endDateTime?.toISOString() ?? 'unlimited',
       hasNextWorldJoin: nextWorldJoin !== null,
     });
 
@@ -349,7 +346,7 @@ const getPlayerJoinListInSameWorldCore = async (
     const playerJoinLogResult =
       await playerJoinLogService.getVRChatPlayerJoinLogListByJoinDateTime({
         startJoinDateTime: worldJoinLog.joinDateTime,
-        endJoinDateTime: endDateTime,
+        endJoinDateTime: endDateTime ?? null,
       });
 
     if (playerJoinLogResult.isErr()) {
@@ -550,7 +547,7 @@ export const logInfoRouter = () =>
         const sessionRanges: Array<{
           dateKey: string;
           start: Date;
-          end: Date;
+          end: Date | undefined;
           worldId: string;
           worldName: string;
           worldInstanceId: string;
@@ -609,12 +606,7 @@ export const logInfoRouter = () =>
               (log) => log.joinDateTime > recentWorldJoin.joinDateTime,
             );
 
-            // 24時間制限（元のロジックと同じ）
-            const endDateTime =
-              nextWorldJoin?.joinDateTime ??
-              new Date(
-                recentWorldJoin.joinDateTime.getTime() + 24 * 60 * 60 * 1000,
-              );
+            const endDateTime = nextWorldJoin?.joinDateTime;
 
             sessionRanges.push({
               dateKey,


### PR DESCRIPTION
## Summary
- Remove 24-hour session limit that was causing photos to be incorrectly ungrouped
- Remove 7-day fallback to allow unlimited session duration
- Optimize LocationGroupHeader query performance with batch processing

## Problem
1. Photos taken during long VRChat sessions (over 24 hours) were being incorrectly categorized as "ungrouped"
2. The artificial 24-hour limit was breaking natural session boundaries
3. LocationGroupHeader queries were causing timeout errors with large datasets

## Solution
- Sessions now continue until the next world join log is detected
- Model layer now supports unlimited date ranges (null end dates)
- Batch processing reduces database load and prevents timeouts

## Test plan
- [x] Verify photos from sessions longer than 24 hours are correctly grouped
- [x] Confirm LocationGroupHeader displays correct player lists
- [x] Check performance with large photo galleries (1000+ photos)
- [x] Ensure no regression in session detection logic

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for open-ended date ranges when retrieving player join logs, allowing queries from a specified start date without requiring an end date.
- **Bug Fixes**
	- Adjusted date range handling so that queries without an end date are no longer limited to a fixed number of days.
- **Refactor**
	- Improved consistency in how open-ended ranges are processed and displayed across related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->