### PR TITLE
Refactor color extraction utilities

### DIFF
--- a/src/v2/utils/colorExtractor.ts
+++ b/src/v2/utils/colorExtractor.ts
@@ -1,3 +1,8 @@
+import {
+  type DominantColors,
+  extractDominantColorsFromImageData,
+} from './dominantColor';
+
 /**
  * 画像要素をキャンバスに描画し、そのピクセルデータを取得するヘルパー。
  * `extractDominantColors` からのみ利用される内部関数。
@@ -15,115 +20,10 @@ function getPixelData(img: HTMLImageElement): ImageData {
 }
 
 /**
- * RGB 値を HSL 値へ変換するユーティリティ関数。
- * 色抽出処理の内部計算に使用される。
- */
-function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
-  const rNorm = r / 255;
-  const gNorm = g / 255;
-  const bNorm = b / 255;
-
-  const max = Math.max(rNorm, gNorm, bNorm);
-  const min = Math.min(rNorm, gNorm, bNorm);
-  let h = 0;
-  let s = 0;
-  const l = (max + min) / 2;
-
-  if (max !== min) {
-    const d = max - min;
-    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-
-    switch (max) {
-      case rNorm:
-        h = (gNorm - bNorm) / d + (gNorm < bNorm ? 6 : 0);
-        break;
-      case gNorm:
-        h = (bNorm - rNorm) / d + 2;
-        break;
-      case bNorm:
-        h = (rNorm - gNorm) / d + 4;
-        break;
-    }
-
-    h /= 6;
-  }
-
-  return [h * 360, s * 100, l * 100];
-}
-
-interface ColorBucket {
-  r: number;
-  g: number;
-  b: number;
-  count: number;
-  hsl: [number, number, number];
-}
-
-/**
  * 与えられた画像から主要な色を抽出する関数。
  * `BoldPreview` や `previewGenerator` で背景色を決定するために使われる。
  */
-export function extractDominantColors(img: HTMLImageElement) {
+export function extractDominantColors(img: HTMLImageElement): DominantColors {
   const imageData = getPixelData(img);
-  const data = imageData.data;
-  const colorBuckets: { [key: string]: ColorBucket } = {};
-
-  for (let i = 0; i < data.length; i += 4) {
-    const r = Math.floor(data[i] / 5) * 5;
-    const g = Math.floor(data[i + 1] / 5) * 5;
-    const b = Math.floor(data[i + 2] / 5) * 5;
-    const alpha = data[i + 3] / 255;
-
-    if (alpha < 0.5) continue;
-
-    const hsl = rgbToHsl(r, g, b);
-    const [, s, l] = hsl;
-
-    if (s < 20 || l < 15 || l > 85) continue;
-
-    const key = `${r},${g},${b}`;
-
-    if (colorBuckets[key]) {
-      colorBuckets[key].count++;
-    } else {
-      colorBuckets[key] = { r, g, b, count: 1, hsl };
-    }
-  }
-
-  const sortedColors = Object.values(colorBuckets)
-    .sort((a, b) => b.count - a.count)
-    .filter((bucket) => bucket.count > 20);
-
-  if (sortedColors.length === 0) {
-    return {
-      primary: 'rgb(59, 130, 246)',
-      secondary: 'rgb(147, 51, 234)',
-      accent: 'rgb(79, 70, 229)',
-    };
-  }
-
-  const hueGroups: { [key: number]: ColorBucket[] } = {};
-  for (const color of sortedColors) {
-    const hueGroup = Math.floor(color.hsl[0] / 30);
-    if (!hueGroups[hueGroup]) {
-      hueGroups[hueGroup] = [];
-    }
-    hueGroups[hueGroup].push(color);
-  }
-
-  const hueGroupsArray = Object.values(hueGroups).sort(
-    (a, b) => b[0].count - a[0].count,
-  );
-
-  const primary = hueGroupsArray[0]?.[0] || sortedColors[0];
-  const secondary =
-    hueGroupsArray[1]?.[0] || sortedColors[Math.floor(sortedColors.length / 3)];
-  const accent =
-    hueGroupsArray[2]?.[0] || sortedColors[Math.floor(sortedColors.length / 2)];
-
-  return {
-    primary: `rgb(${primary.r}, ${primary.g}, ${primary.b})`,
-    secondary: `rgb(${secondary.r}, ${secondary.g}, ${secondary.b})`,
-    accent: `rgb(${accent.r}, ${accent.g}, ${accent.b})`,
-  };
+  return extractDominantColorsFromImageData(imageData.data);
 }

--- a/src/v2/utils/dominantColor.ts
+++ b/src/v2/utils/dominantColor.ts
@@ -1,0 +1,129 @@
+/**
+ * HSL値と支配色を算得するための共通ユーティリティファイル
+ */
+export interface DominantColors {
+  primary: string;
+  secondary: string;
+  accent: string;
+}
+
+export const DEFAULT_COLORS: DominantColors = {
+  primary: 'rgb(59, 130, 246)',
+  secondary: 'rgb(147, 51, 234)',
+  accent: 'rgb(79, 70, 229)',
+};
+
+/**
+ * RGB 値を HSL 値に変換する
+ */
+export function rgbToHsl(
+  r: number,
+  g: number,
+  b: number,
+): [number, number, number] {
+  const rNorm = r / 255;
+  const gNorm = g / 255;
+  const bNorm = b / 255;
+
+  const max = Math.max(rNorm, gNorm, bNorm);
+  const min = Math.min(rNorm, gNorm, bNorm);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+    switch (max) {
+      case rNorm:
+        h = (gNorm - bNorm) / d + (gNorm < bNorm ? 6 : 0);
+        break;
+      case gNorm:
+        h = (bNorm - rNorm) / d + 2;
+        break;
+      case bNorm:
+        h = (rNorm - gNorm) / d + 4;
+        break;
+    }
+
+    h /= 6;
+  }
+
+  return [h * 360, s * 100, l * 100];
+}
+
+/**
+ * ImageData から支配色を抽出する
+ * @param data ImageData.data の配列
+ * @param step RGBAデータを例えば 4 で元のピクセルごとに読み込む
+ */
+export function extractDominantColorsFromImageData(
+  data: Uint8ClampedArray,
+  step = 4,
+): DominantColors {
+  interface ColorBucket {
+    r: number;
+    g: number;
+    b: number;
+    count: number;
+    hsl: [number, number, number];
+  }
+
+  const colorBuckets: { [key: string]: ColorBucket } = {};
+
+  for (let i = 0; i < data.length; i += step) {
+    const r = Math.floor(data[i] / 5) * 5;
+    const g = Math.floor(data[i + 1] / 5) * 5;
+    const b = Math.floor(data[i + 2] / 5) * 5;
+    const alpha = data[i + 3] / 255;
+
+    if (alpha < 0.5) continue;
+
+    const hsl = rgbToHsl(r, g, b);
+    const [, s, l] = hsl;
+
+    if (s < 20 || l < 15 || l > 85) continue;
+
+    const key = `${r},${g},${b}`;
+
+    if (colorBuckets[key]) {
+      colorBuckets[key].count++;
+    } else {
+      colorBuckets[key] = { r, g, b, count: 1, hsl };
+    }
+  }
+
+  const sortedColors = Object.values(colorBuckets)
+    .sort((a, b) => b.count - a.count)
+    .filter((bucket) => bucket.count > 20);
+
+  if (sortedColors.length === 0) {
+    return DEFAULT_COLORS;
+  }
+
+  const hueGroups: { [key: number]: ColorBucket[] } = {};
+  for (const color of sortedColors) {
+    const hueGroup = Math.floor(color.hsl[0] / 30);
+    if (!hueGroups[hueGroup]) {
+      hueGroups[hueGroup] = [];
+    }
+    hueGroups[hueGroup].push(color);
+  }
+
+  const hueGroupsArray = Object.values(hueGroups).sort(
+    (a, b) => b[0].count - a[0].count,
+  );
+
+  const primary = hueGroupsArray[0]?.[0] || sortedColors[0];
+  const secondary =
+    hueGroupsArray[1]?.[0] || sortedColors[Math.floor(sortedColors.length / 3)];
+  const accent =
+    hueGroupsArray[2]?.[0] || sortedColors[Math.floor(sortedColors.length / 2)];
+
+  return {
+    primary: `rgb(${primary.r}, ${primary.g}, ${primary.b})`,
+    secondary: `rgb(${secondary.r}, ${secondary.g}, ${secondary.b})`,
+    accent: `rgb(${accent.r}, ${accent.g}, ${accent.b})`,
+  };
+}

--- a/src/v2/utils/previewGenerator.ts
+++ b/src/v2/utils/previewGenerator.ts
@@ -5,61 +5,18 @@ interface GeneratePreviewParams {
   showAllPlayers: boolean;
 }
 
-interface ColorBucket {
-  r: number;
-  g: number;
-  b: number;
-  count: number;
-  hsl: [number, number, number];
-}
-
-/**
- * RGB 値を HSL 値に変換するヘルパー関数。
- * dominant color 抽出処理から利用される。
- */
-function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
-  const normalizedR = r / 255;
-  const normalizedG = g / 255;
-  const normalizedB = b / 255;
-
-  const max = Math.max(normalizedR, normalizedG, normalizedB);
-  const min = Math.min(normalizedR, normalizedG, normalizedB);
-  let h = 0;
-  let s = 0;
-  const l = (max + min) / 2;
-
-  if (max !== min) {
-    const d = max - min;
-    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-
-    switch (max) {
-      case normalizedR:
-        h =
-          (normalizedG - normalizedB) / d + (normalizedG < normalizedB ? 6 : 0);
-        break;
-      case normalizedG:
-        h = (normalizedB - normalizedR) / d + 2;
-        break;
-      case normalizedB:
-        h = (normalizedR - normalizedG) / d + 4;
-        break;
-    }
-
-    h /= 6;
-  }
-
-  return [h * 360, s * 100, l * 100];
-}
+import {
+  type DominantColors,
+  extractDominantColorsFromImageData,
+} from './dominantColor';
 
 /**
  * 画像データから支配色を抽出する。
  * generatePreviewSvg で背景色を決める際に使われる。
  */
-async function extractDominantColors(imageBase64: string): Promise<{
-  primary: string;
-  secondary: string;
-  accent: string;
-}> {
+async function extractDominantColors(
+  imageBase64: string,
+): Promise<DominantColors> {
   // 画像を読み込む
   const img = new Image();
   img.src = `data:image/png;base64,${imageBase64}`;
@@ -79,79 +36,7 @@ async function extractDominantColors(imageBase64: string): Promise<{
 
   // ピクセルデータを取得
   const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-  const data = imageData.data;
-
-  const colorBuckets: { [key: string]: ColorBucket } = {};
-
-  // 5ピクセルごとにサンプリング（処理を軽くするため）
-  for (let i = 0; i < data.length; i += 20) {
-    const r = Math.floor(data[i] / 5) * 5;
-    const g = Math.floor(data[i + 1] / 5) * 5;
-    const b = Math.floor(data[i + 2] / 5) * 5;
-    const alpha = data[i + 3] / 255;
-
-    if (alpha < 0.5) continue;
-
-    const hsl = rgbToHsl(r, g, b);
-    const [, s, l] = hsl;
-
-    // 彩度と明度でフィルタリング
-    if (s < 20 || l < 15 || l > 85) continue;
-
-    const key = `${r},${g},${b}`;
-
-    if (colorBuckets[key]) {
-      colorBuckets[key].count++;
-    } else {
-      colorBuckets[key] = { r, g, b, count: 1, hsl };
-    }
-  }
-
-  // 出現頻度でソート
-  const sortedColors = Object.values(colorBuckets)
-    .sort((a, b) => b.count - a.count)
-    .filter((bucket) => bucket.count > 20);
-
-  // デフォルトの色
-  const defaultColors = {
-    primary: { r: 59, g: 130, b: 246 },
-    secondary: { r: 147, g: 51, b: 234 },
-    accent: { r: 79, g: 70, b: 229 },
-  };
-
-  if (sortedColors.length === 0) {
-    return {
-      primary: `rgb(${defaultColors.primary.r}, ${defaultColors.primary.g}, ${defaultColors.primary.b})`,
-      secondary: `rgb(${defaultColors.secondary.r}, ${defaultColors.secondary.g}, ${defaultColors.secondary.b})`,
-      accent: `rgb(${defaultColors.accent.r}, ${defaultColors.accent.g}, ${defaultColors.accent.b})`,
-    };
-  }
-
-  // 色相でグループ化
-  const hueGroups: { [key: number]: ColorBucket[] } = {};
-  for (const color of sortedColors) {
-    const hueGroup = Math.floor(color.hsl[0] / 30);
-    if (!hueGroups[hueGroup]) {
-      hueGroups[hueGroup] = [];
-    }
-    hueGroups[hueGroup].push(color);
-  }
-
-  const hueGroupsArray = Object.values(hueGroups).sort(
-    (a, b) => b[0].count - a[0].count,
-  );
-
-  const primary = hueGroupsArray[0]?.[0] || sortedColors[0];
-  const secondary =
-    hueGroupsArray[1]?.[0] || sortedColors[Math.floor(sortedColors.length / 3)];
-  const accent =
-    hueGroupsArray[2]?.[0] || sortedColors[Math.floor(sortedColors.length / 2)];
-
-  return {
-    primary: `rgb(${primary.r}, ${primary.g}, ${primary.b})`,
-    secondary: `rgb(${secondary.r}, ${secondary.g}, ${secondary.b})`,
-    accent: `rgb(${accent.r}, ${accent.g}, ${accent.b})`,
-  };
+  return extractDominantColorsFromImageData(imageData.data, 20);
 }
 
 /**


### PR DESCRIPTION
## Summary
- centralize dominant color computation into `dominantColor.ts`
- simplify `colorExtractor` and `previewGenerator` to use the shared utility

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684e43bce52c832880cfa91d2692fd71