### PR TITLE
fix: PlayerName検索のパフォーマンス最適化

### DIFF
--- a/electron/lib/logger.test.ts
+++ b/electron/lib/logger.test.ts
@@ -2,57 +2,57 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock dependencies
 const mockCaptureException = vi.fn();
-const mockGetTermsAccepted = vi.fn();
-
-vi.mock('@sentry/electron/main', () => ({
-  captureException: mockCaptureException,
-}));
-
-vi.mock('../module/settingStore', () => ({
-  getSettingStore: vi.fn(() => ({
-    getTermsAccepted: mockGetTermsAccepted,
-  })),
-}));
-
-vi.mock('electron-log', () => ({
-  default: {
-    error: vi.fn(),
-    warn: vi.fn(),
-    info: vi.fn(),
-    debug: vi.fn(),
-    transports: {
-      file: {
-        resolvePathFn: vi.fn(),
-        maxSize: 0,
-        level: 'debug',
-        format: '',
-        getFile: () => ({ path: '/test/path' }),
-      },
-      console: {
-        level: 'debug',
-        format: '',
-      },
-    },
-  },
-}));
-
-vi.mock('electron', () => ({
-  app: {
-    getPath: () => '/test/logs',
-    isPackaged: false,
-  },
-}));
-
-// Import logger after mocking
-import { logger } from './logger';
+const mockGetSettingStore = vi.fn();
 
 describe('logger Sentry consent integration', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetAllMocks();
+    vi.resetModules();
+
+    // Set up mocks before importing
+    vi.doMock('electron', () => ({
+      app: {
+        getPath: () => '/test/logs',
+        isPackaged: false,
+      },
+    }));
+
+    vi.doMock('@sentry/electron/main', () => ({
+      captureException: mockCaptureException,
+    }));
+
+    vi.doMock('../module/settingStore', () => ({
+      getSettingStore: mockGetSettingStore,
+    }));
+
+    vi.doMock('electron-log', () => ({
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      transports: {
+        file: {
+          resolvePathFn: vi.fn(),
+          maxSize: 0,
+          level: 'debug',
+          format: '',
+          getFile: () => ({ path: '/test/path' }),
+        },
+        console: {
+          level: 'debug',
+          format: '',
+        },
+      },
+    }));
   });
 
-  it('should not send to Sentry when terms are not accepted', () => {
-    mockGetTermsAccepted.mockReturnValue(false);
+  it('should not send to Sentry when terms are not accepted', async () => {
+    mockGetSettingStore.mockReturnValue({
+      getTermsAccepted: () => false,
+    });
+
+    // Dynamically import logger after mocks are set
+    const { logger } = await import('./logger');
 
     logger.error({ message: 'Test error without consent' });
 
@@ -60,8 +60,13 @@ describe('logger Sentry consent integration', () => {
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
-  it('should send to Sentry when terms are accepted', () => {
-    mockGetTermsAccepted.mockReturnValue(true);
+  it('should send to Sentry when terms are accepted', async () => {
+    mockGetSettingStore.mockReturnValue({
+      getTermsAccepted: () => true,
+    });
+
+    // Dynamically import logger after mocks are set
+    const { logger } = await import('./logger');
 
     logger.error({ message: 'Test error with consent' });
 

--- a/electron/lib/logger.test.ts
+++ b/electron/lib/logger.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock dependencies
+const mockCaptureException = vi.fn();
+const mockGetTermsAccepted = vi.fn();
+
+vi.mock('@sentry/electron/main', () => ({
+  captureException: mockCaptureException,
+}));
+
+vi.mock('../module/settingStore', () => ({
+  getSettingStore: vi.fn(() => ({
+    getTermsAccepted: mockGetTermsAccepted,
+  })),
+}));
+
+vi.mock('electron-log', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    transports: {
+      file: {
+        resolvePathFn: vi.fn(),
+        maxSize: 0,
+        level: 'debug',
+        format: '',
+        getFile: () => ({ path: '/test/path' }),
+      },
+      console: {
+        level: 'debug',
+        format: '',
+      },
+    },
+  },
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/test/logs',
+    isPackaged: false,
+  },
+}));
+
+// Import logger after mocking
+import { logger } from './logger';
+
+describe('logger Sentry consent integration', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should not send to Sentry when terms are not accepted', () => {
+    mockGetTermsAccepted.mockReturnValue(false);
+
+    logger.error({ message: 'Test error without consent' });
+
+    // Sentryが呼ばれていないことを確認
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('should send to Sentry when terms are accepted', () => {
+    mockGetTermsAccepted.mockReturnValue(true);
+
+    logger.error({ message: 'Test error with consent' });
+
+    // Sentryが呼ばれていることを確認
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: {
+          source: 'electron-main',
+        },
+      }),
+    );
+  });
+});

--- a/electron/lib/logger.ts
+++ b/electron/lib/logger.ts
@@ -97,7 +97,7 @@ const error = ({ message, stack }: ErrorLogParams): void => {
   // 規約同意済みの場合のみSentryへ送信
   match(termsAccepted)
     .with(true, () => {
-      logger.debug('Attempting to send error to Sentry...');
+      log.debug('Attempting to send error to Sentry...');
       try {
         captureException(errorInfo, {
           extra: {
@@ -107,13 +107,13 @@ const error = ({ message, stack }: ErrorLogParams): void => {
             source: 'electron-main',
           },
         });
-        logger.debug('Error sent to Sentry successfully');
+        log.debug('Error sent to Sentry successfully');
       } catch (sentryError) {
-        logger.debug('Failed to send error to Sentry:', sentryError);
+        log.debug('Failed to send error to Sentry:', sentryError);
       }
     })
     .otherwise(() => {
-      logger.debug('Terms not accepted, skipping Sentry error');
+      log.debug('Terms not accepted, skipping Sentry error');
     });
 };
 

--- a/electron/module/logInfo/searchSessionsByPlayerName.integration.test.ts
+++ b/electron/module/logInfo/searchSessionsByPlayerName.integration.test.ts
@@ -1,0 +1,121 @@
+import { parseISO } from 'date-fns';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as client from '../../lib/sequelize';
+import { VRChatPlayerJoinLogModel } from '../VRChatPlayerJoinLogModel/playerJoinInfoLog.model';
+import { VRChatWorldJoinLogModel } from '../vrchatWorldJoinLog/VRChatWorldJoinLogModel/s_model';
+import { searchSessionsByPlayerName } from './service';
+
+describe('searchSessionsByPlayerName integration test', () => {
+  beforeAll(async () => {
+    client.__initTestRDBClient();
+  }, 10000);
+
+  beforeEach(async () => {
+    await client.__forceSyncRDBClient();
+  });
+
+  afterAll(async () => {
+    await client.__cleanupTestRDBClient();
+  });
+
+  describe('searchSessionsByPlayerName', () => {
+    it('プレイヤー名で部分一致検索ができる', async () => {
+      // テストデータの準備
+      const worldJoin1 = await VRChatWorldJoinLogModel.create({
+        worldId: 'wrld_test1',
+        worldName: 'Test World 1',
+        worldInstanceId: '12345',
+        joinDateTime: parseISO('2024-01-01T10:00:00'),
+      });
+
+      const worldJoin2 = await VRChatWorldJoinLogModel.create({
+        worldId: 'wrld_test2',
+        worldName: 'Test World 2',
+        worldInstanceId: '67890',
+        joinDateTime: parseISO('2024-01-01T12:00:00'),
+      });
+
+      await VRChatPlayerJoinLogModel.create({
+        playerName: 'TestPlayer123',
+        joinDateTime: parseISO('2024-01-01T10:30:00'),
+      });
+
+      await VRChatPlayerJoinLogModel.create({
+        playerName: 'AnotherPlayer',
+        joinDateTime: parseISO('2024-01-01T10:45:00'),
+      });
+
+      await VRChatPlayerJoinLogModel.create({
+        playerName: 'TestPlayer456',
+        joinDateTime: parseISO('2024-01-01T12:30:00'),
+      });
+
+      // "TestPlayer"で検索
+      const results = await searchSessionsByPlayerName('TestPlayer');
+
+      // 2つのセッションが見つかるはず
+      expect(results).toHaveLength(2);
+      expect(results[0]).toEqual(worldJoin2.joinDateTime);
+      expect(results[1]).toEqual(worldJoin1.joinDateTime);
+    });
+
+    it('大文字小文字を区別しない検索ができる', async () => {
+      await VRChatWorldJoinLogModel.create({
+        worldId: 'wrld_test3',
+        worldName: 'Test World 3',
+        worldInstanceId: '11111',
+        joinDateTime: parseISO('2024-01-02T10:00:00'),
+      });
+
+      await VRChatPlayerJoinLogModel.create({
+        playerName: 'CaseSensitivePlayer',
+        joinDateTime: parseISO('2024-01-02T10:15:00'),
+      });
+
+      // 小文字で検索しても見つかる
+      const results = await searchSessionsByPlayerName('casesensitive');
+      expect(results).toHaveLength(1);
+    });
+
+    it('同じセッションに複数のプレイヤーがいる場合、重複なく1つのセッションを返す', async () => {
+      const worldJoin = await VRChatWorldJoinLogModel.create({
+        worldId: 'wrld_test4',
+        worldName: 'Test World 4',
+        worldInstanceId: '22222',
+        joinDateTime: parseISO('2024-01-03T10:00:00'),
+      });
+
+      await VRChatPlayerJoinLogModel.create({
+        playerName: 'DuplicateTestPlayer1',
+        joinDateTime: parseISO('2024-01-03T10:15:00'),
+      });
+
+      await VRChatPlayerJoinLogModel.create({
+        playerName: 'DuplicateTestPlayer2',
+        joinDateTime: parseISO('2024-01-03T10:30:00'),
+      });
+
+      // "DuplicateTest"で検索
+      const results = await searchSessionsByPlayerName('DuplicateTest');
+
+      // 1つのセッションのみ返される
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual(worldJoin.joinDateTime);
+    });
+
+    it('該当するプレイヤーが存在しない場合、空の配列を返す', async () => {
+      const results = await searchSessionsByPlayerName('NonExistentPlayer');
+      expect(results).toEqual([]);
+    });
+
+    it('プレイヤーは存在するがワールド参加ログがない場合、空の配列を返す', async () => {
+      await VRChatPlayerJoinLogModel.create({
+        playerName: 'PlayerWithoutWorld',
+        joinDateTime: parseISO('2024-01-04T10:00:00'),
+      });
+
+      const results = await searchSessionsByPlayerName('PlayerWithoutWorld');
+      expect(results).toEqual([]);
+    });
+  });
+});

--- a/src/v2/components/PhotoGallery/__tests__/usePhotoGallery.test.ts
+++ b/src/v2/components/PhotoGallery/__tests__/usePhotoGallery.test.ts
@@ -183,6 +183,22 @@ vi.mock('./../../../../trpc', () => ({
           };
         },
       },
+      searchSessionsByPlayerName: {
+        useQuery: ({ playerName }: { playerName: string }) => {
+          // プレイヤー名検索をモック
+          if (playerName.toLowerCase().includes('test player')) {
+            // グループの参加日時を返す
+            return {
+              data: [new Date('2024-01-01T01:00:00Z')],
+              isLoading: false,
+            };
+          }
+          return {
+            data: [],
+            isLoading: false,
+          };
+        },
+      },
     },
   },
 }));


### PR DESCRIPTION
## Summary
- PlayerName検索時のパフォーマンス問題を修正
- バーチャルスクロールの効率性を維持しながら、サーバーサイド検索を実装
- logger Sentryテストを追加（関連する別の修正）

## 問題点
従来の実装では、PlayerName検索時に全セッションのプレイヤーデータを一括取得していたため：
- バーチャルスクロールの利点が失われる
- 大量のメモリを消費
- 検索レスポンスが遅い

## 解決策
1. **サーバーサイド検索**: `searchSessionsByPlayerName`関数でDBレベルの検索を実行
2. **軽量なレスポンス**: 該当セッションの日時のみを返す
3. **遅延読み込み維持**: プレイヤー詳細は表示時のみ取得

## Test plan
- [x] searchSessionsByPlayerName統合テストを追加
- [x] 既存のusePhotoGalleryテストが動作することを確認
- [x] yarn lint通過
- [ ] 手動テスト：大量のセッションでPlayerName検索が高速に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ability to search sessions by player name in the photo gallery, enabling users to find session photos based on player participation.

- **Bug Fixes**
  - Improved search logic to accurately distinguish between world name and player name searches for more relevant results.

- **Tests**
  - Introduced comprehensive tests for player name-based session search functionality and Sentry consent logic in error reporting.

- **Refactor**
  - Streamlined search implementation for better performance and maintainability by shifting player search to the server side.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->