### PR TITLE
feat: 検索候補選択時の検索タイプ明示的指定機能を追加

### DIFF
--- a/src/v2/components/AppHeader.tsx
+++ b/src/v2/components/AppHeader.tsx
@@ -20,7 +20,7 @@ import SearchCombobox from './SearchCombobox';
 
 interface AppHeaderProps {
   searchQuery?: string;
-  setSearchQuery?: (query: string) => void;
+  setSearchQuery?: (query: string, type?: 'world' | 'player') => void;
   onOpenSettings?: () => void;
   selectedPhotoCount?: number;
   onClearSelection?: () => void;

--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -22,6 +22,8 @@ interface GalleryContentProps
   > {
   /** ヘッダーから渡される検索クエリ */
   searchQuery: string;
+  /** 検索タイプ（world | player | undefined） */
+  searchType?: 'world' | 'player';
   /** ギャラリーデータ（統合AppHeaderに渡す） */
   galleryData?: PhotoGalleryData;
 }
@@ -79,6 +81,7 @@ const SkeletonGroup = () => (
 const GalleryContent = memo(
   ({
     searchQuery,
+    searchType,
     isLoadingStartupSync,
     isLoadingGrouping,
     finishLoadingGrouping,
@@ -92,7 +95,9 @@ const GalleryContent = memo(
       setSelectedPhotos,
       isMultiSelectMode,
       setIsMultiSelectMode,
-    } = usePhotoGallery(searchQuery, { onGroupingEnd: finishLoadingGrouping });
+    } = usePhotoGallery(searchQuery, searchType, {
+      onGroupingEnd: finishLoadingGrouping,
+    });
     const containerRef = useRef<HTMLDivElement>(null);
     const groupSizesRef = useRef<Map<string, number>>(new Map());
 

--- a/src/v2/components/SearchCombobox.tsx
+++ b/src/v2/components/SearchCombobox.tsx
@@ -5,7 +5,7 @@ import SearchOverlay from './SearchOverlay';
 
 interface SearchComboboxProps {
   searchQuery: string;
-  onSearch: (query: string) => void;
+  onSearch: (query: string, type?: 'world' | 'player') => void;
   className?: string;
 }
 
@@ -26,8 +26,8 @@ const SearchCombobox = memo(
       setIsOverlayOpen(false);
     };
 
-    const handleSearch = (query: string) => {
-      onSearch(query);
+    const handleSearch = (query: string, type?: 'world' | 'player') => {
+      onSearch(query, type);
       setIsOverlayOpen(false);
     };
 

--- a/src/v2/components/SearchOverlay.tsx
+++ b/src/v2/components/SearchOverlay.tsx
@@ -6,7 +6,7 @@ import { useI18n } from '../i18n/store';
 interface SearchOverlayProps {
   isOpen: boolean;
   onClose: () => void;
-  onSearch: (query: string) => void;
+  onSearch: (query: string, type?: 'world' | 'player') => void;
   initialQuery?: string;
 }
 
@@ -151,7 +151,7 @@ const SearchOverlay = memo(
           case 'Enter':
             e.preventDefault();
             if (suggestions[highlightedIndex]) {
-              handleSelect(suggestions[highlightedIndex].value);
+              handleSelect(suggestions[highlightedIndex]);
             } else {
               handleSearch();
             }
@@ -166,9 +166,12 @@ const SearchOverlay = memo(
 
     // 候補選択
     const handleSelect = useCallback(
-      (value: string) => {
-        setQuery(value);
-        onSearch(value);
+      (suggestion: SearchSuggestion) => {
+        setQuery(suggestion.value);
+        onSearch(
+          suggestion.value,
+          suggestion.type === 'recent' ? undefined : suggestion.type,
+        );
         onClose();
       },
       [onSearch, onClose],
@@ -290,11 +293,11 @@ const SearchOverlay = memo(
                           ? 'bg-primary/10 dark:bg-primary/20'
                           : 'hover:bg-gray-100/50 dark:hover:bg-gray-800/50'
                       }`}
-                      onClick={() => handleSelect(suggestion.value)}
+                      onClick={() => handleSelect(suggestion)}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault();
-                          handleSelect(suggestion.value);
+                          handleSelect(suggestion);
                         }
                       }}
                       onMouseEnter={() => setHighlightedIndex(index)}


### PR DESCRIPTION
検索候補(ワールド名/プレイヤー名)を選択した際に、その候補タイプに応じた
検索処理のみを実行するように改善しました。

変更内容:
- SearchOverlay: 候補選択時にタイプ(world/player)を伝播
- SearchCombobox, PhotoGallery, AppHeader: タイプ情報の受け渡し対応
- usePhotoGallery: 明示的なタイプ指定による検索フィルタリング実装
  - searchType="world": ワールド名検索のみ実行
  - searchType="player": プレイヤー名検索のみ実行
  - タイプ未指定: 従来のヒューリスティック検索

効果:
- ワールド名とプレイヤー名が重複する場合の検索精度向上
- 不要な検索処理の削減によるパフォーマンス改善

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced search functionality across the photo gallery, search bar, and overlays to support filtering by both query and search type (either "world" or "player").
  - Users can now specify the search type for more precise results in galleries and search interfaces.

- **Bug Fixes**
  - Improved consistency in search handling when selecting suggestions or using different search interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->