### PR TITLE
feat: 初回起動時の自動起動設定をデフォルトTrueに変更

### DIFF
--- a/electron/module/backgroundSettings/controller/backgroundSettingsController.ts
+++ b/electron/module/backgroundSettings/controller/backgroundSettingsController.ts
@@ -12,8 +12,9 @@ const getIsBackgroundFileCreationEnabled =
   (settingStore: ReturnType<typeof getSettingStore>) =>
   async (): Promise<boolean> => {
     const flag = settingStore.getBackgroundFileCreateFlag();
+    // デフォルトは true にする
     console.log('flag', flag);
-    return flag ?? false;
+    return flag ?? true;
   };
 
 /**

--- a/electron/module/settings/settingsController.ts
+++ b/electron/module/settings/settingsController.ts
@@ -216,6 +216,24 @@ export const settingsRouter = () =>
           }, using ${syncMode} sync mode`,
         );
 
+        // Step 3.5: 初回起動時に自動起動を有効化
+        if (isFirstLaunch) {
+          logger.info(
+            'Step 3.5: Setting default auto-start enabled for first launch...',
+          );
+          try {
+            const { app } = await import('electron');
+            app.setLoginItemSettings({
+              openAtLogin: true,
+              openAsHidden: true,
+            });
+            logger.info('Auto-start enabled by default for first launch');
+          } catch (error) {
+            logger.warn('Failed to set default auto-start:', error);
+            // 自動起動の設定に失敗してもアプリの初期化は続行
+          }
+        }
+
         // Step 4: ログ同期実行
         logger.info('Step 4: Starting log sync...');
         const logSyncResult = await syncLogs(syncMode);


### PR DESCRIPTION
- 初回起動時に自動起動を有効化するロジックを追加
- バックグラウンドファイル作成のデフォルト値を false から true に変更


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The app now attempts to enable auto-start on system login during the first launch, improving convenience for new users.

- **Bug Fixes**
  - The default setting for background file creation is now enabled if the preference is unset, ensuring expected behavior for new installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->