### PR TITLE
feat: 写真クリック時にOSの標準写真ビューアーで開くように変更

### DIFF
--- a/src/v2/components/PhotoCard.tsx
+++ b/src/v2/components/PhotoCard.tsx
@@ -25,8 +25,6 @@ interface PhotoCardProps {
   photo: Photo;
   /** 画像を優先的に読み込むか (ビューポート内の最初の要素など) */
   priority?: boolean;
-  /** 写真本体がクリックされたときに呼び出されるコールバック (通常モード時、モーダル表示用) */
-  onSelect: (photo: Photo) => void;
   /** 現在選択されている写真のIDセット */
   selectedPhotos: Set<string>;
   /** 選択されている写真のIDセットを更新する関数 */
@@ -51,7 +49,6 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
   ({
     photo,
     priority = false,
-    onSelect,
     selectedPhotos,
     setSelectedPhotos,
     photos,
@@ -141,10 +138,16 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
           return newSelected;
         });
       } else {
-        // 通常モード中: モーダル表示
-        onSelect(photo);
+        // 通常モード中: システムの写真ビューアで開く
+        openInPhotoAppMutation.mutate(photo.url);
       }
-    }, [isMultiSelectMode, currentPhotoId, setSelectedPhotos, onSelect, photo]);
+    }, [
+      isMultiSelectMode,
+      currentPhotoId,
+      setSelectedPhotos,
+      photo.url,
+      openInPhotoAppMutation,
+    ]);
 
     /** 左上の選択アイコンのクリックハンドラ */
     const handleSelectIconClick = useCallback(

--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -7,7 +7,6 @@ import { AppHeader } from '../AppHeader';
 import { LocationGroupHeader } from '../LocationGroupHeader';
 import type { PhotoGalleryData } from '../PhotoGallery';
 import PhotoGrid from '../PhotoGrid';
-import PhotoModal from '../PhotoModal';
 import { GalleryErrorBoundary } from './GalleryErrorBoundary';
 import { MeasurePhotoGroup } from './MeasurePhotoGroup';
 import { usePhotoGallery } from './usePhotoGallery';
@@ -89,8 +88,6 @@ const GalleryContent = memo(
   }: GalleryContentProps) => {
     const {
       groupedPhotos,
-      selectedPhoto,
-      setSelectedPhoto,
       selectedPhotos,
       setSelectedPhotos,
       isMultiSelectMode,
@@ -219,7 +216,6 @@ const GalleryContent = memo(
                       <div className="w-full rounded-b-lg overflow-hidden">
                         <PhotoGrid
                           photos={group.photos}
-                          onPhotoSelect={setSelectedPhoto}
                           selectedPhotos={selectedPhotos}
                           setSelectedPhotos={setSelectedPhotos}
                           isMultiSelectMode={isMultiSelectMode}
@@ -246,12 +242,6 @@ const GalleryContent = memo(
             </div>
           )}
         </div>
-        {selectedPhoto && (
-          <PhotoModal
-            photo={selectedPhoto}
-            onClose={() => setSelectedPhoto(null)}
-          />
-        )}
       </GalleryErrorBoundary>
     );
   },

--- a/src/v2/components/PhotoGrid.tsx
+++ b/src/v2/components/PhotoGrid.tsx
@@ -11,8 +11,6 @@ import PhotoCard from './PhotoCard';
 interface PhotoGridProps {
   /** 表示する写真オブジェクトの配列 */
   photos: Photo[];
-  /** 写真がクリックされたときに呼び出されるコールバック (モーダル表示用) */
-  onPhotoSelect: (photo: Photo) => void;
   /** 現在選択されている写真のIDセット */
   selectedPhotos: Set<string>;
   /** 選択されている写真のIDセットを更新する関数 */
@@ -59,7 +57,6 @@ interface PhotoGridProps {
  */
 export default function PhotoGrid({
   photos,
-  onPhotoSelect,
   selectedPhotos,
   setSelectedPhotos,
   isMultiSelectMode,
@@ -100,7 +97,6 @@ export default function PhotoGrid({
                   >
                     <PhotoCard
                       photo={photo}
-                      onSelect={onPhotoSelect}
                       priority={index === 0}
                       selectedPhotos={selectedPhotos}
                       setSelectedPhotos={setSelectedPhotos}


### PR DESCRIPTION
## Summary
- 写真クリック時の動作を変更し、内蔵のPhotoModalではなくOSの標準写真ビューアーで開くようにしました
- 既存の「写真アプリで開く」コンテキストメニュー機能を活用

## Changes
- PhotoCardのクリックハンドラを修正（内蔵モーダル表示 → システムビューアで開く）
- PhotoModalコンポーネントの使用箇所を削除
- 不要になったonSelectプロパティを関連コンポーネントから削除

## Test plan
- [x] 写真をクリックしてOSの標準写真ビューアーが開くことを確認
- [x] 複数選択モードでの動作が変わらないことを確認
- [x] コンテキストメニューの他の機能が正常に動作することを確認
- [x] yarn lint:fix と yarn lint でエラーがないことを確認
- [x] yarn test でテストが全て通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Clicking a photo now opens it directly in the system's photo viewer application.
- **Removed**
	- The ability to open photos in a modal within the app has been removed.
	- Single-photo selection and related modal display features have been eliminated from the gallery interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->