### PR TITLE
Refactor color utilities

### DIFF
--- a/src/v2/utils/fontLoader.ts
+++ b/src/v2/utils/fontLoader.ts
@@ -1,0 +1,6 @@
+export async function loadInterFonts(): Promise<void> {
+  await document.fonts.load('700 1em Inter');
+  await document.fonts.load('600 1em Inter');
+  await document.fonts.load('500 1em Inter');
+  await document.fonts.load('400 1em Inter');
+}

--- a/src/v2/utils/shareUtils.ts
+++ b/src/v2/utils/shareUtils.ts
@@ -1,3 +1,5 @@
+import { loadInterFonts } from './fontLoader';
+
 interface ShareImageOptions {
   pngBase64: string;
   filenameWithoutExt: string;
@@ -43,10 +45,7 @@ const _processSvgElement = async (
   const svgDataUrl = `data:image/svg+xml;base64,${svgBase64}`;
 
   // フォントを読み込む
-  await document.fonts.load('700 1em Inter');
-  await document.fonts.load('600 1em Inter');
-  await document.fonts.load('500 1em Inter');
-  await document.fonts.load('400 1em Inter');
+  await loadInterFonts();
 
   // SVGをcanvasに描画
   return new Promise<HTMLCanvasElement>((resolve, reject) => {


### PR DESCRIPTION
## Summary
- share dominant color extraction logic in `colorExtractor.ts`
- extract font loading helper `loadInterFonts`
- reuse new helpers in `previewGenerator` and `shareUtils`
- move `rgbToHsl` import to top of file

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6852cf498f2c8328bc4e7c7425350f34