### PR TITLE
Centralize SVG rendering

### DIFF
--- a/src/v2/utils/shareUtils.ts
+++ b/src/v2/utils/shareUtils.ts
@@ -1,4 +1,4 @@
-import { loadInterFonts } from './fontLoader';
+import { renderSvgToCanvas } from './svgToCanvas';
 
 interface ShareImageOptions {
   pngBase64: string;
@@ -39,46 +39,10 @@ const _processSvgElement = async (
     div.style.fontFamily = 'Inter, sans-serif';
   }
 
-  // SVGをデータURLに変換
   const svgData = new XMLSerializer().serializeToString(svgElement);
-  const svgBase64 = btoa(unescape(encodeURIComponent(svgData)));
-  const svgDataUrl = `data:image/svg+xml;base64,${svgBase64}`;
+  const { width, height } = extractSvgWidthAndHeight(svgElement);
 
-  // フォントを読み込む
-  await loadInterFonts();
-
-  // SVGをcanvasに描画
-  return new Promise<HTMLCanvasElement>((resolve, reject) => {
-    const img = new Image();
-    img.crossOrigin = 'anonymous';
-
-    const { width, height } = extractSvgWidthAndHeight(svgElement);
-
-    img.onload = () => {
-      const canvas = document.createElement('canvas');
-      canvas.width = width * 2;
-      canvas.height = height * 2;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) {
-        reject(new Error('Failed to get canvas context'));
-        return;
-      }
-
-      // 背景を白に設定
-      ctx.fillStyle = 'white';
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-      // 画像を描画
-      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-      resolve(canvas);
-    };
-
-    img.onerror = () => {
-      reject(new Error('Failed to load SVG'));
-    };
-
-    img.src = svgDataUrl;
-  });
+  return renderSvgToCanvas(svgData, width, height);
 };
 
 /**

--- a/src/v2/utils/svgToCanvas.ts
+++ b/src/v2/utils/svgToCanvas.ts
@@ -1,0 +1,38 @@
+export async function renderSvgToCanvas(
+  svg: string,
+  width: number,
+  height: number,
+): Promise<HTMLCanvasElement> {
+  // フォントを読み込む
+  const { loadInterFonts } = await import('./fontLoader');
+  await loadInterFonts();
+
+  const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+
+  try {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.src = url;
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error('Failed to load SVG'));
+    });
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width * 2;
+    canvas.height = height * 2;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Failed to get canvas context');
+
+    // 背景を白で塗りつぶす
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    // SVG画像を描画
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+    return canvas;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}


### PR DESCRIPTION
## Summary
- centralize SVG to canvas logic
- reuse the helper in shareUtils and previewGenerator

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68579c9ed9a4832883a9fc69eaed02d7