### PR TITLE
feat: 写真ギャラリーに日付ジャンプサイドバー機能を実装

### DIFF
--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -141,42 +141,22 @@ const GalleryContent = memo(
     // 日付ジャンプハンドラー
     const handleJumpToDate = useCallback(
       (groupIndex: number) => {
-        const isFirstGroup = groupIndex === 0;
-        const isLastGroup = groupIndex === filteredGroups.length - 1;
-
-        // 基本のスクロール処理
+        // 即座にジャンプ（アニメーションなし）
         virtualizer.scrollToIndex(groupIndex, {
-          behavior: 'smooth',
+          behavior: 'auto',
           align: 'start',
         });
 
-        // 最初と最後のグループには追加の余白調整
-        setTimeout(() => {
-          if (!containerRef.current) return;
-
-          const virtualItems = virtualizer.getVirtualItems();
-          const targetItem = virtualItems.find(
-            (item) => item.index === groupIndex,
-          );
-
-          if (isFirstGroup) {
-            // 最初のグループは完全に上部にスクロール
-            containerRef.current.scrollTop = 0;
-          } else if (isLastGroup && targetItem) {
-            // 最後のグループは上に100pxの余白を持たせる
-            const scrollPosition = Math.max(0, targetItem.start - 100);
-            containerRef.current.scrollTop = scrollPosition;
-          } else if (targetItem) {
-            // 中間のグループは中央寄せ
-            const containerHeight = containerRef.current.clientHeight;
-            const itemHeight = targetItem.size;
-            const scrollPosition =
-              targetItem.start - (containerHeight - itemHeight) / 2;
-            containerRef.current.scrollTop = Math.max(0, scrollPosition);
-          }
-        }, 150);
+        // バーチャルスクロールの更新を強制
+        requestAnimationFrame(() => {
+          // 再度確実にジャンプ（バーチャルスクロールの測定が完了後）
+          virtualizer.scrollToIndex(groupIndex, {
+            behavior: 'auto',
+            align: 'start',
+          });
+        });
       },
-      [virtualizer, filteredGroups.length],
+      [virtualizer],
     );
 
     // IntersectionObserverでビューポート内のグループを検知


### PR DESCRIPTION
## Summary
- Google Photos風のミニマルなデザインで日付ジャンプサイドバーを実装
- ホバー/スクロール時のみ表示される控えめなUI設計
- バーチャルスクロール環境でも動作する高速なジャンプ機能

## Changes
- `DateJumpSidebar`コンポーネントを新規作成
- 日付ごとにドット表示し、クリックで該当日付にジャンプ
- 年ラベルとホバー時の日付ポップアップ表示
- アニメーションを最小限に抑えた高速なレスポンス

## Test plan
- [ ] ギャラリーを開いて右端にホバーするとサイドバーが表示される
- [ ] サイドバーをクリックすると該当日付にジャンプする
- [ ] スクロール中もサイドバーが表示される
- [ ] 年ラベルが各年の最初の位置に正しく表示される
- [ ] ホバー時の日付ポップアップが素早く表示される