### PR TITLE
feat: Add photo selection order display and sorting

### DIFF
--- a/src/v2/components/PhotoCard.tsx
+++ b/src/v2/components/PhotoCard.tsx
@@ -25,11 +25,13 @@ interface PhotoCardProps {
   photo: Photo;
   /** 画像を優先的に読み込むか (ビューポート内の最初の要素など) */
   priority?: boolean;
-  /** 現在選択されている写真のIDセット */
-  selectedPhotos: Set<string>;
-  /** 選択されている写真のIDセットを更新する関数 */
+  /** 現在選択されている写真のIDと選択順序のマップ */
+  selectedPhotos: Map<string, number>;
+  /** 選択されている写真のIDと選択順序のマップを更新する関数 */
   setSelectedPhotos: (
-    update: Set<string> | ((prev: Set<string>) => Set<string>),
+    update:
+      | Map<string, number>
+      | ((prev: Map<string, number>) => Map<string, number>),
   ) => void;
   /** このカードが含まれるグリッド全体の写真リスト (複数コピー時のパス取得用、将来的に不要かも) */
   photos: Photo[];
@@ -68,6 +70,8 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
     const currentPhotoId = String(photo.id);
     /** このカードが現在選択されているかどうか */
     const isSelected = selectedPhotos.has(currentPhotoId);
+    /** このカードの選択順序（選択されていない場合はundefined） */
+    const selectionOrder = selectedPhotos.get(currentPhotoId);
 
     /** 画像を読み込むべきか (優先指定またはビューポート内) */
     const shouldLoad = priority || isIntersecting;
@@ -99,8 +103,12 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
     const handleCopyPhotoData = (e: React.MouseEvent) => {
       e.stopPropagation();
       if (selectedPhotos.size > 1) {
-        const pathsToCopy = Array.from(selectedPhotos)
-          .map((id) => {
+        // 選択順序でソート
+        const sortedEntries = Array.from(selectedPhotos.entries()).sort(
+          (a, b) => a[1] - b[1],
+        );
+        const pathsToCopy = sortedEntries
+          .map(([id]) => {
             const p = photos.find((p) => String(p.id) === id);
             return p?.url;
           })
@@ -129,11 +137,13 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
       if (isMultiSelectMode) {
         // 複数選択モード中: 選択/選択解除
         setSelectedPhotos((prev) => {
-          const newSelected = new Set(prev);
+          const newSelected = new Map(prev);
           if (newSelected.has(currentPhotoId)) {
             newSelected.delete(currentPhotoId);
           } else {
-            newSelected.add(currentPhotoId);
+            // 新しい選択順序を追加（最大値+1）
+            const maxOrder = Math.max(0, ...Array.from(newSelected.values()));
+            newSelected.set(currentPhotoId, maxOrder + 1);
           }
           return newSelected;
         });
@@ -159,11 +169,13 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
         }
 
         setSelectedPhotos((prev) => {
-          const newSelected = new Set(prev);
+          const newSelected = new Map(prev);
           if (newSelected.has(currentPhotoId)) {
             newSelected.delete(currentPhotoId);
           } else {
-            newSelected.add(currentPhotoId);
+            // 新しい選択順序を追加（最大値+1）
+            const maxOrder = Math.max(0, ...Array.from(newSelected.values()));
+            newSelected.set(currentPhotoId, maxOrder + 1);
           }
           return newSelected;
         });
@@ -180,7 +192,9 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
     const handleContextMenu = useCallback(() => {
       if (!isMultiSelectMode || !selectedPhotos.has(currentPhotoId)) {
         // モード外 or 未選択写真を右クリック: これを選択しモード開始
-        setSelectedPhotos(new Set([currentPhotoId]));
+        const newSelected = new Map<string, number>();
+        newSelected.set(currentPhotoId, 1);
+        setSelectedPhotos(newSelected);
         setIsMultiSelectMode(true);
       }
     }, [
@@ -250,11 +264,20 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
               tabIndex={0}
             >
               {isSelected ? (
-                <CheckCircle2
-                  size={24}
-                  className="text-blue-500 dark:text-blue-400 bg-white dark:bg-gray-800 rounded-full shadow-sm"
-                  strokeWidth={2.5}
-                />
+                <div className="relative">
+                  <CheckCircle2
+                    size={24}
+                    className="text-blue-500 dark:text-blue-400 bg-white dark:bg-gray-800 rounded-full shadow-sm"
+                    strokeWidth={2.5}
+                  />
+                  {selectionOrder && (
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <span className="text-xs font-bold text-white dark:text-gray-900">
+                        {selectionOrder}
+                      </span>
+                    </div>
+                  )}
+                </div>
               ) : (
                 <Circle
                   size={24}

--- a/src/v2/components/PhotoGallery.tsx
+++ b/src/v2/components/PhotoGallery.tsx
@@ -53,7 +53,7 @@ const PhotoGallery = memo((props: PhotoGalleryProps) => {
 
   /** 選択をクリアし、複数選択モードを解除するハンドラ */
   const handleClearSelection = () => {
-    setSelectedPhotos(new Set());
+    setSelectedPhotos(new Map());
     setIsMultiSelectMode(false);
   };
 
@@ -92,14 +92,20 @@ const PhotoGallery = memo((props: PhotoGalleryProps) => {
       return;
     }
 
-    // 選択された写真のパスを取得
-    const selectedPhotoUrls: string[] = [];
+    // 選択された写真を選択順序でソート
+    const sortedEntries = Array.from(selectedPhotos.entries()).sort(
+      (a, b) => a[1] - b[1],
+    );
 
-    // グループ内の写真からIDが一致するものを探す
-    for (const group of Object.values(groupedPhotos)) {
-      for (const photo of group.photos) {
-        if (selectedPhotos.has(photo.id.toString())) {
+    // 選択順序でソートされたパスを取得
+    const selectedPhotoUrls: string[] = [];
+    for (const [photoId] of sortedEntries) {
+      // グループ内の写真からIDが一致するものを探す
+      for (const group of Object.values(groupedPhotos)) {
+        const photo = group.photos.find((p) => p.id.toString() === photoId);
+        if (photo) {
           selectedPhotoUrls.push(photo.url);
+          break;
         }
       }
     }

--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -206,7 +206,7 @@ const GalleryContent = memo(
           | React.KeyboardEvent<HTMLDivElement>,
       ) => {
         if (event.target === containerRef.current && isMultiSelectMode) {
-          setSelectedPhotos(new Set());
+          setSelectedPhotos(new Map());
           setIsMultiSelectMode(false);
         }
       },

--- a/src/v2/components/PhotoGallery/usePhotoGallery.ts
+++ b/src/v2/components/PhotoGallery/usePhotoGallery.ts
@@ -28,8 +28,8 @@ interface GalleryDebugInfo {
 
 /** 表示中の写真（モーダル表示用） */
 const selectedPhotoAtom = atom<Photo | null>(null);
-/** 選択されている写真のIDセット */
-const selectedPhotosAtom = atom<Set<string>>(new Set<string>());
+/** 選択されている写真のIDと選択順序のマップ（key: photoId, value: 選択順序 1から始まる） */
+const selectedPhotosAtom = atom<Map<string, number>>(new Map<string, number>());
 /** 複数選択モードかどうか */
 const isMultiSelectModeAtom = atom<boolean>(false);
 
@@ -61,11 +61,13 @@ export function usePhotoGallery(
   selectedPhoto: Photo | null;
   /** モーダル表示する写真オブジェクトを設定する関数 */
   setSelectedPhoto: (photo: Photo | null) => void;
-  /** 現在選択されている写真のIDセット */
-  selectedPhotos: Set<string>;
-  /** 選択されている写真のIDセットを更新する関数 */
+  /** 現在選択されている写真のIDと選択順序のマップ */
+  selectedPhotos: Map<string, number>;
+  /** 選択されている写真のIDと選択順序のマップを更新する関数 */
   setSelectedPhotos: (
-    update: Set<string> | ((prev: Set<string>) => Set<string>),
+    update:
+      | Map<string, number>
+      | ((prev: Map<string, number>) => Map<string, number>),
   ) => void;
   /** 現在複数選択モードかどうか */
   isMultiSelectMode: boolean;

--- a/src/v2/components/PhotoGrid.tsx
+++ b/src/v2/components/PhotoGrid.tsx
@@ -11,11 +11,13 @@ import PhotoCard from './PhotoCard';
 interface PhotoGridProps {
   /** 表示する写真オブジェクトの配列 */
   photos: Photo[];
-  /** 現在選択されている写真のIDセット */
-  selectedPhotos: Set<string>;
-  /** 選択されている写真のIDセットを更新する関数 */
+  /** 現在選択されている写真のIDと選択順序のマップ */
+  selectedPhotos: Map<string, number>;
+  /** 選択されている写真のIDと選択順序のマップを更新する関数 */
   setSelectedPhotos: (
-    update: Set<string> | ((prev: Set<string>) => Set<string>),
+    update:
+      | Map<string, number>
+      | ((prev: Map<string, number>) => Map<string, number>),
   ) => void;
   /** 現在複数選択モードかどうか */
   isMultiSelectMode: boolean;


### PR DESCRIPTION
## Summary
- Display selection order numbers on selected photos
- Copy photos in the order they were selected
- Maintain visual feedback for selection sequence

## Changes
- Changed selectedPhotosAtom from Set<string> to Map<string, number>
- Added selection order display in PhotoCard component
- Updated photo copy functionality to sort by selection order
- Modified selection logic to track order (1-indexed)
- Updated all related components for new data structure

## Test plan
- [x] Test photo selection shows correct order numbers
- [x] Verify copying preserves selection order
- [x] Test deselection removes from map correctly
- [x] Confirm UI updates properly with selection changes
- [x] Test with large number of selected photos

🤖 Generated with [Claude Code](https://claude.ai/code)