### PR TITLE
refactor: Replace Node.js path with pathe library

### DIFF
--- a/electron/electronUtil.ts
+++ b/electron/electronUtil.ts
@@ -1,7 +1,7 @@
 // Native
 import EventEmitter from 'node:events';
 import { promises as fs } from 'node:fs';
-import { join } from 'node:path';
+import { join } from 'pathe';
 
 // Packages
 import {

--- a/electron/index.ts
+++ b/electron/index.ts
@@ -1,6 +1,6 @@
-import path from 'node:path';
 import { type BrowserWindow, app, ipcMain } from 'electron';
 import isDev from 'electron-is-dev';
+import path from 'pathe';
 
 import {
   type Event,
@@ -142,10 +142,7 @@ const createOrGetMainWindow = async (): Promise<BrowserWindow> => {
  * ファイルパスはユーザーデータディレクトリ配下に生成される。
  */
 const initializeRDBClient = async () => {
-  const filePath = path
-    .join(getAppUserDataPath(), 'db.sqlite')
-    .split(path.sep)
-    .join(path.posix.sep);
+  const filePath = path.join(getAppUserDataPath(), 'db.sqlite');
   sequelizeClient.initRDBClient({
     db_url: filePath,
   });

--- a/electron/module/electronUtil/service.ts
+++ b/electron/module/electronUtil/service.ts
@@ -1,9 +1,9 @@
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
-import * as path from 'node:path';
 import { writeClipboardFilePaths } from 'clip-filepaths';
 import { app, clipboard, dialog, nativeImage, shell } from 'electron';
 import * as neverthrow from 'neverthrow';
+import * as path from 'pathe';
 import sharp from 'sharp';
 
 /**

--- a/electron/module/service.ts
+++ b/electron/module/service.ts
@@ -1,6 +1,6 @@
 import type * as neverthrow from 'neverthrow';
 
-import path from 'node:path';
+import path from 'pathe';
 import { logger } from './../lib/logger';
 // import * as infoFileService from './joinLogInfoFile/service';
 // import { getToCreateWorldJoinLogInfos } from './joinLogInfoFile/service';

--- a/electron/module/settingStore.ts
+++ b/electron/module/settingStore.ts
@@ -150,8 +150,8 @@ const clearStoredSetting =
     }
   };
 
-import path from 'node:path';
 import consola from 'consola';
+import path from 'pathe';
 import { logger } from './../lib/logger';
 import {
   type VRChatPhotoDirPath,

--- a/electron/module/vrchatLog/fileHandlers/logStorageManager.ts
+++ b/electron/module/vrchatLog/fileHandlers/logStorageManager.ts
@@ -1,7 +1,7 @@
 import * as nodeFs from 'node:fs';
-import path from 'node:path';
 import * as datefns from 'date-fns';
 import * as neverthrow from 'neverthrow';
+import path from 'pathe';
 import { getAppUserDataPath } from '../../../lib/wrappedApp';
 import * as fs from '../../../lib/wrappedFs';
 import type { VRChatLogLine, VRChatLogStoreFilePath } from '../model';

--- a/electron/module/vrchatLog/fileHandlers/photoLogImporter.ts
+++ b/electron/module/vrchatLog/fileHandlers/photoLogImporter.ts
@@ -1,6 +1,6 @@
-import path from 'node:path';
 import * as datefns from 'date-fns';
 import { glob } from 'glob';
+import path from 'pathe';
 import type { VRChatPhotoDirPath } from '../../vrchatPhoto/valueObjects';
 import { createVRChatWorldJoinLogFromPhoto } from '../../vrchatWorldJoinLogFromPhoto/service';
 import type { VRChatWorldJoinLogFromPhoto } from '../../vrchatWorldJoinLogFromPhoto/vrchatWorldJoinLogFromPhoto.model';
@@ -22,11 +22,7 @@ const getLogLinesFromLogPhotoDirPath = async ({
 }: { vrChatPhotoDirPath: VRChatPhotoDirPath }): Promise<
   VRChatWorldJoinLogFromPhoto[]
 > => {
-  const globPath = path.posix.join(
-    vrChatPhotoDirPath.value,
-    '**',
-    'VRChat_*_wrld_*',
-  );
+  const globPath = path.join(vrChatPhotoDirPath.value, '**', 'VRChat_*_wrld_*');
   // 正規表現にマッチするファイルを再帰的に取得
   const logPhotoFilePathList = await glob(globPath);
 

--- a/electron/module/vrchatLog/model.ts
+++ b/electron/module/vrchatLog/model.ts
@@ -1,7 +1,7 @@
 const opaqueSymbol: unique symbol = Symbol('opaqueSymbol');
 
-import * as path from 'node:path';
 import * as datefns from 'date-fns';
+import * as path from 'pathe';
 import { z } from 'zod';
 
 export abstract class BaseValueObject<T extends string, K> {

--- a/electron/module/vrchatLogFileDir/service.ts
+++ b/electron/module/vrchatLogFileDir/service.ts
@@ -1,5 +1,5 @@
-import path from 'node:path';
 import * as neverthrow from 'neverthrow';
+import path from 'pathe';
 import { P, match } from 'ts-pattern';
 // import type * as vrchatLogService from '../service/vrchatLog/vrchatLog';
 import * as fs from '../../lib/wrappedFs';


### PR DESCRIPTION
## Summary
- Replace Node.js built-in path module with pathe library
- Improve cross-platform path handling
- Modernize path utilities throughout the codebase

## Changes
- Update imports from 'node:path' to 'pathe'
- Replace path operations with pathe equivalents
- Ensure consistent path handling across all modules

## Test plan
- [ ] Verify all path operations work correctly on different platforms
- [ ] Check that existing functionality is preserved
- [ ] Run tests to ensure no breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)