### PR TITLE
fix: 入力要素のスタイル統一とSSH agent forwarding設定 (#526)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,9 @@
 {
   "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+  "mounts": ["source=${env:SSH_AUTH_SOCK},target=/ssh-agent,type=bind"],
+  "remoteEnv": {
+    "SSH_AUTH_SOCK": "/ssh-agent"
+  },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "image": "mcr.microsoft.com/devcontainers/base:bookworm",
-  "mounts": ["source=${env:SSH_AUTH_SOCK},target=/ssh-agent,type=bind"],
+  "mounts": [
+    "source=${env:SSH_AUTH_SOCK},target=/ssh-agent,type=bind,readOnly=true"
+  ],
   "remoteEnv": {
     "SSH_AUTH_SOCK": "/ssh-agent"
   },

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -12,7 +12,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-10 w-full rounded-md border border-input bg-background/50 backdrop-blur-sm px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground transition-all duration-200 hover:bg-background/70 hover:border-input/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:bg-background focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50 shadow-sm',
           className,
         )}
         ref={ref}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -12,7 +12,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         ref={ref}

--- a/src/index.css
+++ b/src/index.css
@@ -28,7 +28,7 @@
     --popover-foreground: 220 9% 15%;
  
     --border: 220 10% 90% / 0.3;
-    --input: 220 10% 95% / 0.4;
+    --input: 220 10% 85% / 0.5;
  
     --card: 0 0% 100% / 0.7;
     --card-foreground: 220 9% 15%;
@@ -76,7 +76,7 @@
     --popover-foreground: 220 15% 85%;
  
     --border: 220 27% 20% / 0.3;
-    --input: 220 27% 16% / 0.4;
+    --input: 220 27% 25% / 0.5;
  
     --card: 220 27% 12% / 0.7;
     --card-foreground: 220 15% 85%;

--- a/src/v2/components/settings/PathSettings.tsx
+++ b/src/v2/components/settings/PathSettings.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { trpcReact } from '@/trpc';
 import {
   AlertCircle,
@@ -288,36 +290,38 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
               {t('settings.paths.photoDirectory')}
             </label>
             <div className="flex gap-2">
-              <input
+              <Input
                 type="text"
                 aria-label={`input-${t('settings.paths.photoDirectory')}`}
                 value={photoInputValue}
                 onChange={handlePhotoInputChange}
                 placeholder="/path/to/photos"
-                className="flex-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                className="flex-1"
               />
               {isPhotoPathManuallyChanged ? (
-                <button
+                <Button
                   type="button"
                   aria-label={`${t('common.submit')}-${t(
                     'settings.paths.photoDirectory',
                   )}`}
-                  className="px-3 py-2 bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700 rounded-md text-sm text-white"
+                  variant="default"
+                  size="sm"
                   onClick={handlePhotoPathSave}
                 >
                   <Save className="h-4 w-4" />
-                </button>
+                </Button>
               ) : (
-                <button
+                <Button
                   type="button"
                   aria-label={`${t('settings.paths.browse')}-${t(
                     'settings.paths.photoDirectory',
                   )}`}
-                  className="px-3 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-md text-sm text-gray-700 dark:text-gray-200"
+                  variant="secondary"
+                  size="sm"
                   onClick={handleBrowsePhotoDirectory}
                 >
                   <FolderOpen className="h-4 w-4" />
-                </button>
+                </Button>
               )}
             </div>
             {photoValidationResult && photoValidationResult !== 'VALID' && (
@@ -342,35 +346,35 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
               </label>
               <div className="mt-1 space-y-2">
                 {extraDirs.map((dir: string, index: number) => (
-                  <div
-                    key={`extra-dir-${dir}`}
-                    className="flex rounded-md shadow-sm"
-                  >
-                    <input
+                  <div key={`extra-dir-${dir}`} className="flex gap-2">
+                    <Input
                       type="text"
                       value={dir}
                       readOnly
-                      className="flex-1 block w-full rounded-l-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-white"
+                      className="flex-1"
                     />
-                    <button
+                    <Button
                       type="button"
                       onClick={() => handleRemoveExtraDirectory(index)}
                       aria-label={t('settings.paths.removeExtraDirectory')}
-                      className="px-3 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-r-md text-sm text-gray-700 dark:text-gray-200 border border-l-0 border-gray-300 dark:border-gray-600"
+                      variant="secondary"
+                      size="sm"
                     >
                       <Trash className="h-4 w-4" />
-                    </button>
+                    </Button>
                   </div>
                 ))}
-                <button
+                <Button
                   type="button"
                   onClick={handleBrowseExtraDirectory}
                   aria-label={t('settings.paths.addExtraDirectory')}
-                  className="flex items-center px-3 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-md text-sm text-gray-700 dark:text-gray-200"
+                  variant="secondary"
+                  size="sm"
+                  className="w-full"
                 >
                   <Plus className="h-4 w-4 mr-2" />
                   フォルダを追加
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -381,36 +385,38 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
               {t('settings.paths.logFile')}
             </label>
             <div className="flex gap-2">
-              <input
+              <Input
                 type="text"
                 aria-label={`input-${t('settings.paths.logFile')}`}
                 value={logInputValue}
                 onChange={handleLogInputChange}
                 placeholder="/path/to/photo-logs.json"
-                className="flex-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                className="flex-1"
               />
               {isLogPathManuallyChanged ? (
-                <button
+                <Button
                   type="button"
                   aria-label={`${t('common.submit')}-${t(
                     'settings.paths.logFile',
                   )}`}
-                  className="px-3 py-2 bg-blue-500 hover:bg-blue-600 dark:bg-blue-600 dark:hover:bg-blue-700 rounded-md text-sm text-white"
+                  variant="default"
+                  size="sm"
                   onClick={handleLogPathSave}
                 >
                   <Save className="h-4 w-4" />
-                </button>
+                </Button>
               ) : (
-                <button
+                <Button
                   type="button"
                   aria-label={`${t('settings.paths.browse')}-${t(
                     'settings.paths.logFile',
                   )}`}
-                  className="px-3 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-md text-sm text-gray-700 dark:text-gray-200"
+                  variant="secondary"
+                  size="sm"
                   onClick={handleBrowseLogFile}
                 >
                   <FolderOpen className="h-4 w-4" />
-                </button>
+                </Button>
               )}
             </div>
             {logFilesDir?.error && (


### PR DESCRIPTION
## Summary
- input要素のスタイル統一を実装 (#526)
- 開発環境でのSSH agent forwarding設定を追加

## Changes
- `src/components/ui/input.tsx`: text-base md:text-sm を text-sm に統一
- `src/v2/components/settings/PathSettings.tsx`: カスタムスタイルのinput/buttonをshadcn/uiコンポーネントに置き換え
- `.devcontainer/devcontainer.json`: SSH agent forwarding設定を追加

## Test plan
- [ ] 各input要素のスタイルが統一されていることを確認
- [ ] PathSettings画面のinput/buttonが正しく動作することを確認
- [ ] Devcontainerが正常にビルドされることを確認
- [ ] コンテナ内でSSH agentが利用可能なことを確認

Closes #526

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated settings interface to use consistent, custom input and button components for a more unified look and feel.

* **Style**
  * Enhanced input field styling with improved transitions, modern background effects, and subtle shadows.
  * Adjusted input background colors and transparency for both light and dark themes to improve visual clarity.

* **Chores**
  * Enabled SSH agent forwarding in the development container configuration for improved workflow integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->