### PR TITLE
fix: 初回起動と通常起動で異なるローディングメッセージを表示

### DIFF
--- a/src/v2/App.tsx
+++ b/src/v2/App.tsx
@@ -482,7 +482,32 @@ const Contents = () => {
   }
 
   if (stage === 'syncing') {
-    const currentStage = 'アプリケーションを初期化中...';
+    // 既存ログ数を取得して初回起動かどうかを判定
+    // 最新1週間のログを取得して、ログが存在するかチェック
+    const oneWeekAgo = new Date();
+    oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+
+    const { data: existingLogs } =
+      trpcReact.vrchatWorldJoinLog.getVRChatWorldJoinLogList.useQuery(
+        {
+          gtJoinDateTime: oneWeekAgo,
+          orderByJoinDateTime: 'desc',
+        },
+        {
+          // エラーは無視して、取得できなければ初回起動として扱う
+          retry: false,
+          staleTime: 0,
+          refetchOnWindowFocus: false,
+        },
+      );
+
+    const isFirstLaunch = !existingLogs || existingLogs.length === 0;
+    const currentStage = isFirstLaunch
+      ? 'アプリケーションを初期化中...'
+      : 'データを読み込み中...';
+    const subMessage = isFirstLaunch
+      ? '写真とログファイルを準備しています'
+      : '最新のデータを取得しています';
 
     return (
       <div className="h-screen flex flex-col overflow-hidden bg-[#f9f9fa] dark:bg-[#1c1c1e]">
@@ -544,7 +569,7 @@ const Contents = () => {
                 {currentStage}
               </h2>
               <p className="text-sm text-gray-500 dark:text-gray-500">
-                写真とログファイルを準備しています
+                {subMessage}
               </p>
             </div>
 


### PR DESCRIPTION
## 概要
初回起動時と通常起動時で異なるローディングメッセージを表示するように改善しました。

## 問題
- 初回起動時も通常起動時も「アプリケーションを初期化中...」と表示されていた
- ユーザーにとって実際の処理内容がわかりにくかった

## 変更内容
- 最新1週間のログの有無で初回起動を判定
- 初回起動時: "アプリケーションを初期化中..." / "写真とログファイルを準備しています"  
- 通常起動時: "データを読み込み中..." / "最新のデータを取得しています"

## 関連Issue
Fixes #530

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The syncing screen now displays different messages based on whether this is your first launch or not, providing clearer feedback during initialization.

* **Style**
  * Updated sub-messages on the syncing screen to dynamically reflect the current state of data preparation or loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->