### PR TITLE
feat(#529): ウィンドウヘッダーのダブルクリックで最大化/復元機能

### DIFF
--- a/src/v2/components/AppHeader.tsx
+++ b/src/v2/components/AppHeader.tsx
@@ -109,6 +109,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
     <div
       className="flex h-9 items-center justify-between px-2 select-none border-b dark:border-gray-700"
       style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+      onDoubleClick={handleMaximize}
     >
       {/* 左側: ギャラリーコントロール */}
       <div


### PR DESCRIPTION
## Summary
- AppHeaderコンポーネントにonDoubleClickイベントを追加
- ウィンドウヘッダーをダブルクリックすることで最大化/復元を切り替えられるようになりました
- macOSの標準的な動作と同様の操作感を実現

## Test plan
- [ ] ウィンドウヘッダーをダブルクリックして最大化できることを確認
- [ ] 最大化状態でウィンドウヘッダーをダブルクリックして元のサイズに戻ることを確認
- [ ] ボタンなどのインタラクティブ要素でのダブルクリックが誤動作しないことを確認

関連: #529

🤖 Generated with [Claude Code](https://claude.ai/code)