### PR TITLE
Add design doc references

### DIFF
--- a/electron/lib/dbQueue.ts
+++ b/electron/lib/dbQueue.ts
@@ -46,6 +46,9 @@ interface DBQueueOptions {
  * データベースアクセスのためのキュー
  * - 同時実行数を制限してデータベースアクセスをキューイングする
  * - トランザクション処理をサポート
+ *
+ * @see docs/log-sync-architecture.md - ログ同期設計ドキュメント
+ * @see electron/module/logSync/service.ts - 主要サービスクラス
  */
 class DBQueue {
   private queue: PQueue;

--- a/electron/lib/errors.ts
+++ b/electron/lib/errors.ts
@@ -55,6 +55,13 @@ export interface StructuredErrorInfo {
   cause?: Error;
 }
 
+/**
+ * ユーザー向けエラーの基底クラス
+ *
+ * @see docs/error-handling.md - 詳細なエラーハンドリング方針
+ * @see electron/lib/errorHelpers.ts
+ * @see electron/lib/logger.ts
+ */
 export class UserFacingError extends Error {
   public readonly errorInfo?: StructuredErrorInfo;
 

--- a/src/v2/components/LocationGroupHeader/hooks/useSessionInfoBatch.ts
+++ b/src/v2/components/LocationGroupHeader/hooks/useSessionInfoBatch.ts
@@ -24,6 +24,9 @@ interface BatchRequest {
 /**
  * プレイヤー情報バッチマネージャー
  * 設定されたウィンドウ時間で複数のリクエストをまとめて一つのDBクエリで処理
+ *
+ * @see docs/log-sync-architecture.md - ログ同期設計ドキュメント
+ * @see electron/lib/dbQueue.ts
  */
 class PlayerInfoBatchManager {
   private pendingRequests: BatchRequest[] = [];

--- a/src/v2/components/PhotoGallery/GalleryErrorBoundary.tsx
+++ b/src/v2/components/PhotoGallery/GalleryErrorBoundary.tsx
@@ -16,6 +16,9 @@ interface State {
 /**
  * ギャラリー表示中の予期せぬエラーを捕捉して再読み込みを促すバウンダリ。
  * PathSettings へのリンクも表示し、環境設定をやり直せるようにする。
+ *
+ * @see docs/error-handling.md - エラーハンドリング設計ドキュメント
+ * @see electron/lib/errors.ts
  */
 export class GalleryErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {

--- a/src/v2/utils/justifiedLayoutCalculator.ts
+++ b/src/v2/utils/justifiedLayoutCalculator.ts
@@ -40,6 +40,10 @@ export interface LayoutResult {
  * const result = calculator.calculateLayout(photos, containerWidth);
  * const height = calculator.calculateTotalHeight(photos, containerWidth);
  * ```
+ *
+ * @see docs/date-jump-architecture.md - 日付ジャンプ機能の設計
+ * @see PhotoGrid
+ * @see MeasurePhotoGroup
  */
 export class JustifiedLayoutCalculator {
   private readonly constants: LayoutConstants;

--- a/src/valueObjects/index.ts
+++ b/src/valueObjects/index.ts
@@ -5,6 +5,9 @@ import { BaseValueObject } from '../../electron/lib/baseValueObject.js';
 /**
  * VRChatの写真ファイル名
  * VRChat_2023-10-01_03-01-18.551_2560x1440.png
+ *
+ * @see docs/photo-grouping-logic.md - 写真グループ化ロジック
+ * @see electron/module/vrchatPhoto/model/vrchatPhotoPath.model.ts
  */
 class VRChatPhotoFileNameWithExt extends BaseValueObject<
   'VRChatPhotoFileNameWithExt',


### PR DESCRIPTION
## Summary
- note the log sync architecture docs in DBQueue
- reference the error handling doc in error classes and gallery error boundary
- link date jump design notes for JustifiedLayoutCalculator
- document related classes in PlayerInfoBatchManager and value objects

## Testing
- `yarn lint:fix`
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_685f57482ebc8328a4a1e486bc77326a