### PR TITLE
refactor: アイコンサイズの統一と定数化

### DIFF
--- a/src/v2/components/AppHeader.tsx
+++ b/src/v2/components/AppHeader.tsx
@@ -13,6 +13,7 @@ import {
 import type React from 'react';
 import { useEffect, useState } from 'react';
 import { trpcReact as trpc } from '../../trpc';
+import { ICON_SIZE } from '../constants/ui';
 import type { UseLoadingStateResult } from '../hooks/useLoadingState';
 import { LOG_SYNC_MODE, useLogSync } from '../hooks/useLogSync';
 import { useI18n } from '../i18n/store';
@@ -125,7 +126,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
                   onClick={onClearSelection}
                   className="h-7 w-7 p-0"
                 >
-                  <X className="h-4 w-4" />
+                  <X className={ICON_SIZE.sm.class} />
                 </Button>
                 <span className="text-xs font-medium px-2">
                   {selectedPhotoCount}件
@@ -138,7 +139,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
                   className="h-7 w-7 p-0"
                   title={t('common.contextMenu.copyPhotoData')}
                 >
-                  <Copy className="h-4 w-4" />
+                  <Copy className={ICON_SIZE.sm.class} />
                 </Button>
               </>
             ) : (
@@ -149,7 +150,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
                   onClick={onOpenSettings}
                   className="h-7 w-7 p-0"
                 >
-                  <Settings className="h-4 w-4" />
+                  <Settings className={ICON_SIZE.sm.class} />
                 </Button>
                 <Button
                   variant="ghost"
@@ -160,7 +161,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
                   title={t('common.refresh')}
                 >
                   <RefreshCw
-                    className={`h-4 w-4 ${
+                    className={`${ICON_SIZE.sm.class} ${
                       loadingState?.isRefreshing ? 'animate-spin' : ''
                     }`}
                   />
@@ -194,7 +195,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             className="h-7 w-7 p-0 hover:bg-green-500/15 text-green-500/70 hover:text-green-500 transition-colors duration-150"
             title="アップデートをインストール"
           >
-            <Download className="h-4 w-4" />
+            <Download className={ICON_SIZE.sm.class} />
           </Button>
         )}
         <Button
@@ -203,7 +204,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           onClick={handleMinimize}
           className="h-7 w-7 p-0 hover:bg-muted/40 text-muted-foreground/60 hover:text-muted-foreground transition-colors duration-150"
         >
-          <Minus className="h-4 w-4" />
+          <Minus className={ICON_SIZE.sm.class} />
         </Button>
         <Button
           variant="ghost"
@@ -211,7 +212,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           onClick={handleMaximize}
           className="h-7 w-7 p-0 hover:bg-muted/40 text-muted-foreground/60 hover:text-muted-foreground transition-colors duration-150"
         >
-          <Square className="h-4 w-4" />
+          <Square className={ICON_SIZE.sm.class} />
         </Button>
         <Button
           variant="ghost"
@@ -219,7 +220,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           onClick={handleClose}
           className="h-7 w-7 p-0 hover:bg-red-500/80 text-muted-foreground/60 hover:text-white transition-colors duration-150"
         >
-          <X className="h-4 w-4" />
+          <X className={ICON_SIZE.sm.class} />
         </Button>
       </div>
     </div>

--- a/src/v2/components/LocationGroupHeader/PlatformBadge.tsx
+++ b/src/v2/components/LocationGroupHeader/PlatformBadge.tsx
@@ -1,5 +1,6 @@
 import { Laptop } from 'lucide-react';
 import { memo } from 'react';
+import { ICON_SIZE } from '../../constants/ui';
 
 interface PlatformBadgeProps {
   platform: string;
@@ -18,7 +19,7 @@ export const PlatformBadge = memo(({ platform }: PlatformBadgeProps) => {
         : platform;
   return (
     <span className="inline-flex items-center px-2 py-0.5 rounded text-sm font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200">
-      <Laptop className="h-3 w-3 mr-1" />
+      <Laptop className={`${ICON_SIZE.xs.class} mr-1`} />
       {platformName}
     </span>
   );

--- a/src/v2/components/LocationGroupHeader/ShareDialog.tsx
+++ b/src/v2/components/LocationGroupHeader/ShareDialog.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../components/ui/dialog';
 import { Label } from '../../../components/ui/label';
 import { Switch } from '../../../components/ui/switch';
+import { ICON_SIZE } from '../../constants/ui';
 import { useI18n } from '../../i18n/store';
 import { generatePreviewPng } from '../../utils/previewGenerator';
 import { downloadOrCopyImageAsPng } from '../../utils/shareUtils';
@@ -139,7 +140,7 @@ export const ShareDialog = ({
               className="p-2 rounded-lg bg-white/20 dark:bg-gray-800/50 hover:bg-white/30 dark:hover:bg-gray-800/60 border border-white/10 dark:border-gray-700/30 text-gray-700 dark:text-gray-200 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
               title={t('locationHeader.copyToClipboard')}
             >
-              <Copy className="h-5 w-5" />
+              <Copy className={ICON_SIZE.md.class} />
             </button>
             <button
               type="button"
@@ -148,7 +149,7 @@ export const ShareDialog = ({
               className="p-2 rounded-lg bg-white/20 dark:bg-gray-800/50 hover:bg-white/30 dark:hover:bg-gray-800/60 border border-white/10 dark:border-gray-700/30 text-gray-700 dark:text-gray-200 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
               title={t('locationHeader.downloadImage')}
             >
-              <Download className="h-5 w-5" />
+              <Download className={ICON_SIZE.md.class} />
             </button>
           </div>
         </DialogHeader>
@@ -160,7 +161,9 @@ export const ShareDialog = ({
                   <div className="w-full">
                     {isLoading || isGeneratingPreview ? (
                       <div className="flex items-center justify-center">
-                        <LoaderCircle className="h-8 w-8 animate-spin text-blue-500" />
+                        <LoaderCircle
+                          className={`${ICON_SIZE.lg.class} animate-spin text-blue-500`}
+                        />
                       </div>
                     ) : (
                       <div className="flex items-center justify-center">
@@ -182,7 +185,7 @@ export const ShareDialog = ({
                   onClick={handleCopyShareImageToClipboard}
                   disabled={isLoading}
                 >
-                  <Copy className="h-4 w-4" />
+                  <Copy className={ICON_SIZE.sm.class} />
                   <span>{t('locationHeader.copyToClipboard')}</span>
                 </ContextMenuItem>
                 <ContextMenuItem
@@ -190,7 +193,7 @@ export const ShareDialog = ({
                   onClick={handleDownloadShareImagePng}
                   disabled={isLoading}
                 >
-                  <Download className="h-4 w-4" />
+                  <Download className={ICON_SIZE.sm.class} />
                   <span>{t('locationHeader.downloadImage')}</span>
                 </ContextMenuItem>
               </ContextMenuContent>

--- a/src/v2/components/LocationGroupHeader/index.tsx
+++ b/src/v2/components/LocationGroupHeader/index.tsx
@@ -12,6 +12,7 @@ import {
 import { useEffect, useRef, useState } from 'react';
 import type { ReactPortal } from 'react';
 import { createPortal } from 'react-dom';
+import { ICON_SIZE } from '../../constants/ui';
 import { useI18n } from '../../i18n/store';
 import { PlatformBadge } from './PlatformBadge';
 import { type Player, PlayerList } from './PlayerList';
@@ -201,14 +202,16 @@ export const LocationGroupHeader = ({
             {t('locationHeader.ungrouped')}
           </h2>
           <span className="flex items-center gap-2 px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded-full">
-            <ImageIcon className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+            <ImageIcon
+              className={`${ICON_SIZE.sm.class} text-gray-500 dark:text-gray-400`}
+            />
             <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
               {photoCount}
             </span>
           </span>
         </div>
         <div className="mt-2 text-sm text-gray-500 dark:text-gray-400 flex items-center gap-2">
-          <Calendar className="h-4 w-4" />
+          <Calendar className={ICON_SIZE.sm.class} />
           <time dateTime={joinDateTime.toISOString()}>{formattedDate}</time>
         </div>
       </header>
@@ -271,7 +274,9 @@ export const LocationGroupHeader = ({
                   className="h-20 rounded-lg bg-gray-200 dark:bg-gray-800 flex items-center justify-center border border-white/20 dark:border-gray-700/30"
                   style={{ aspectRatio: '4/3' }}
                 >
-                  <ImageIcon className="h-8 w-8 text-gray-400 dark:text-gray-600" />
+                  <ImageIcon
+                    className={`${ICON_SIZE.lg.class} text-gray-400 dark:text-gray-600`}
+                  />
                 </div>
               )}
             </div>
@@ -292,12 +297,16 @@ export const LocationGroupHeader = ({
                     <span className="line-clamp-1 text-start">
                       {details?.name || worldName}
                     </span>
-                    <ExternalLink className="h-4 w-4 ml-2 transition-opacity flex-shrink-0" />
+                    <ExternalLink
+                      className={`${ICON_SIZE.sm.class} ml-2 transition-opacity flex-shrink-0`}
+                    />
                   </button>
                 </h3>
                 <div className="flex items-center gap-2 flex-shrink-0">
                   <div className="flex items-center text-sm text-gray-800 dark:text-white backdrop-blur-sm bg-white/30 dark:bg-black/30 px-3 py-1 rounded-full border border-white/20 dark:border-gray-700/30">
-                    <Calendar className="h-4 w-4 mr-1.5 text-primary-600 dark:text-primary-300" />
+                    <Calendar
+                      className={`${ICON_SIZE.sm.class} mr-1.5 text-primary-600 dark:text-primary-300`}
+                    />
                     {formattedDate}
                   </div>
                   {details?.unityPackages &&
@@ -317,7 +326,7 @@ export const LocationGroupHeader = ({
                     onClick={openShareModal}
                     className="flex items-center text-sm font-medium text-gray-800 dark:text-white backdrop-blur-sm bg-primary-500/10 hover:bg-primary-500/20 dark:bg-primary-500/30 dark:hover:bg-primary-500/40 px-3 py-1 rounded-full transition-all duration-300 border border-white/20 dark:border-white/10 hover:border-white/30 dark:hover:border-white/20"
                   >
-                    <Share2 className="h-4 w-4 mr-1.5" />
+                    <Share2 className={`${ICON_SIZE.sm.class} mr-1.5`} />
                   </button>
                 </div>
               </div>
@@ -327,7 +336,9 @@ export const LocationGroupHeader = ({
                 {isPlayersLoading ? (
                   <div className="flex gap-2 items-center text-xs text-gray-800 dark:text-white backdrop-blur-sm bg-white/30 dark:bg-black/30 px-3 py-1 rounded-full border border-white/20 dark:border-gray-700/30 flex-1 min-w-0 animate-pulse">
                     <div className="flex items-center gap-1">
-                      <Users className="h-4 w-4 text-primary-600/50 dark:text-primary-300/50 flex-shrink-0" />
+                      <Users
+                        className={`${ICON_SIZE.sm.class} text-primary-600/50 dark:text-primary-300/50 flex-shrink-0`}
+                      />
                       <div className="h-4 w-6 bg-gray-200/70 dark:bg-black/40 rounded" />
                     </div>
                     <div className="text-gray-500/50 dark:text-gray-400/50">
@@ -344,7 +355,9 @@ export const LocationGroupHeader = ({
                   players.length > 0 && (
                     <div className="flex gap-2 items-center text-xs text-gray-800 dark:text-white backdrop-blur-sm bg-white/30 hover:bg-white/40 dark:bg-black/30 dark:hover:bg-black/40 px-3 py-1 rounded-full transition-all duration-300 border border-white/20 dark:border-gray-700/30 hover:border-white/30 dark:hover:border-gray-700/40 group/players flex-1 min-w-0">
                       <div className="flex items-center gap-1">
-                        <Users className="h-4 w-4 text-primary-600 dark:text-primary-300 flex-shrink-0" />
+                        <Users
+                          className={`${ICON_SIZE.sm.class} text-primary-600 dark:text-primary-300 flex-shrink-0`}
+                        />
                         <span>{players.length}</span>
                       </div>
                       <div className="text-gray-500 dark:text-gray-400">|</div>
@@ -373,7 +386,7 @@ export const LocationGroupHeader = ({
                             />
                           ) : (
                             <span className="text-green-400 flex items-center gap-2">
-                              <CheckIcon className="h-4 w-4" />
+                              <CheckIcon className={ICON_SIZE.sm.class} />
                               {t('locationHeader.copied')}
                             </span>
                           )}
@@ -405,7 +418,9 @@ export const LocationGroupHeader = ({
                             document.body,
                           ) as ReactPortal)}
                       </div>
-                      <Copy className="h-4 w-4 ml-2 text-gray-800 dark:text-white group-hover/players:text-gray-200 transition-colors flex-shrink-0" />
+                      <Copy
+                        className={`${ICON_SIZE.sm.class} ml-2 text-gray-800 dark:text-white group-hover/players:text-gray-200 transition-colors flex-shrink-0`}
+                      />
                     </div>
                   )
                 )}

--- a/src/v2/components/PhotoCard.tsx
+++ b/src/v2/components/PhotoCard.tsx
@@ -11,6 +11,7 @@ import pathe from 'pathe';
 import type React from 'react';
 import { memo, useCallback, useRef, useState } from 'react';
 import { P, match } from 'ts-pattern';
+import { ICON_SIZE } from '../constants/ui';
 import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
 import { useI18n } from '../i18n/store';
 import type { Photo } from '../types/photo';
@@ -251,13 +252,13 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
             >
               {isSelected ? (
                 <CheckCircle2
-                  size={24}
+                  size={ICON_SIZE.photo.pixels}
                   className="text-blue-500 dark:text-blue-400 bg-white dark:bg-gray-800 rounded-full shadow-sm"
                   strokeWidth={2.5}
                 />
               ) : (
                 <Circle
-                  size={24}
+                  size={ICON_SIZE.photo.pixels}
                   className="text-white/90 bg-gray-900/40 backdrop-blur-sm rounded-full hover:bg-gray-900/60 transition-colors duration-75"
                   strokeWidth={2}
                 />

--- a/src/v2/components/SearchOverlay.tsx
+++ b/src/v2/components/SearchOverlay.tsx
@@ -1,6 +1,7 @@
 import { trpcReact } from '@/trpc';
 import { Globe, Search, User, X } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { ICON_SIZE } from '../constants/ui';
 import { useI18n } from '../i18n/store';
 
 interface SearchOverlayProps {
@@ -240,7 +241,9 @@ const SearchOverlay = memo(
           >
             {/* 検索入力部分 */}
             <div className="flex items-center p-4 border-b border-gray-200/30 dark:border-gray-700/30">
-              <Search className="h-5 w-5 text-muted-foreground/40 mr-3 flex-shrink-0" />
+              <Search
+                className={`${ICON_SIZE.md.class} text-muted-foreground/40 mr-3 flex-shrink-0`}
+              />
               <input
                 ref={inputRef}
                 type="text"
@@ -261,7 +264,9 @@ const SearchOverlay = memo(
                   className="ml-3 p-1.5 hover:bg-gray-100/50 dark:hover:bg-gray-800/50 rounded-lg transition-colors"
                   aria-label="検索をクリア"
                 >
-                  <X className="h-4 w-4 text-muted-foreground/60" />
+                  <X
+                    className={`${ICON_SIZE.sm.class} text-muted-foreground/60`}
+                  />
                 </button>
               )}
             </div>
@@ -306,9 +311,13 @@ const SearchOverlay = memo(
                       tabIndex={0}
                     >
                       {suggestion.type === 'world' ? (
-                        <Globe className="h-4 w-4 mr-3 text-muted-foreground" />
+                        <Globe
+                          className={`${ICON_SIZE.sm.class} mr-3 text-muted-foreground`}
+                        />
                       ) : (
-                        <User className="h-4 w-4 mr-3 text-muted-foreground" />
+                        <User
+                          className={`${ICON_SIZE.sm.class} mr-3 text-muted-foreground`}
+                        />
                       )}
                       <span className="flex-1 font-medium text-gray-900 dark:text-gray-100">
                         {suggestion.label}
@@ -337,7 +346,8 @@ const SearchOverlay = memo(
                   onClick={handleSearch}
                   className="w-full flex items-center justify-center px-4 py-2 bg-primary/10 hover:bg-primary/20 dark:bg-primary/20 dark:hover:bg-primary/30 text-primary font-medium rounded-xl transition-colors"
                 >
-                  <Search className="h-4 w-4 mr-2" />「{query}」で検索
+                  <Search className={`${ICON_SIZE.sm.class} mr-2`} />「{query}
+                  」で検索
                 </button>
               </div>
             )}

--- a/src/v2/constants/ui.ts
+++ b/src/v2/constants/ui.ts
@@ -1,0 +1,38 @@
+/**
+ * UIコンポーネントで使用する共通定数を一元管理
+ */
+
+/**
+ * アイコンサイズの標準定義
+ * Tailwindクラスとピクセルサイズの両方に対応
+ */
+export const ICON_SIZE = {
+  /** 極小サイズ (12px) - バッジ等で使用 */
+  xs: {
+    class: 'h-3 w-3',
+    pixels: 12,
+  },
+  /** 小サイズ (16px) - デフォルトサイズ */
+  sm: {
+    class: 'h-4 w-4',
+    pixels: 16,
+  },
+  /** 中サイズ (20px) - ボタンアイコン等で使用 */
+  md: {
+    class: 'h-5 w-5',
+    pixels: 20,
+  },
+  /** 大サイズ (32px) - ローディングアイコン等で使用 */
+  lg: {
+    class: 'h-8 w-8',
+    pixels: 32,
+  },
+  /** 特大サイズ (24px) - PhotoCard専用 */
+  photo: {
+    class: 'h-6 w-6',
+    pixels: 24,
+  },
+} as const;
+
+export type IconSizeKey = keyof typeof ICON_SIZE;
+export type IconSizeValue = (typeof ICON_SIZE)[IconSizeKey];


### PR DESCRIPTION
## Summary
- アイコンサイズの管理を一元化し、コードの保守性を向上
- ハードコードされたサイズを定数に置き換えてUIの一貫性を確保
- TypeScriptの型安全性を活用してコンパイル時チェックを実現

## Changes
- `src/v2/constants/ui.ts`に標準アイコンサイズ定数を定義
- 各コンポーネントでハードコードされたサイズを定数に置き換え:
  - AppHeader: `h-4 w-4` → `ICON_SIZE.sm.class`
  - PhotoCard: `size={24}` → `ICON_SIZE.photo.pixels`
  - LocationGroupHeader: 全てのアイコンサイズを定数化
  - SearchOverlay: 全てのアイコンサイズを定数化
  - ShareDialog: 全てのアイコンサイズを定数化
  - PlatformBadge: `h-3 w-3` → `ICON_SIZE.xs.class`

## Test plan
- [x] yarn lint:fix と yarn lint でコードスタイルの確認
- [x] yarn test で既存テストの動作確認
- [ ] 各コンポーネントのアイコンが正しいサイズで表示されることを視覚的に確認
- [ ] レスポンシブデザインでの表示確認

## Related
- #541

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized icon sizing across the app by replacing hardcoded size classes with centralized size constants for improved consistency and maintainability.

* **New Features**
  * Introduced a centralized set of icon size constants for uniform styling throughout the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->