### PR TITLE
fix(#549): logLoad中のエラーハンドリングを改善し、部分的な成功を許容

### DIFF
--- a/electron/module/logInfo/service.test.ts
+++ b/electron/module/logInfo/service.test.ts
@@ -43,6 +43,17 @@ vi.mock('../vrchatLog/service', () => ({
   getVRChaLogInfoByLogFilePathList: vi.fn().mockImplementation(() => {
     return neverthrow.ok([]);
   }),
+  getVRChaLogInfoByLogFilePathListWithPartialSuccess: vi
+    .fn()
+    .mockImplementation(() => {
+      return Promise.resolve({
+        data: [],
+        errors: [],
+        totalProcessed: 0,
+        successCount: 0,
+        errorCount: 0,
+      });
+    }),
   getLegacyLogStoreFilePath: vi.fn().mockImplementation(async () => {
     // モックでレガシーファイルパスを返す
     const legacyPath = path.join('/mock/user/data/logStore', 'logStore.txt');
@@ -178,11 +189,17 @@ describe('loadLogInfoIndexFromVRChatLog', () => {
 
     // このテスト用にgetVRChaLogInfoByLogFilePathListをカスタマイズ
     vi.mocked(
-      vrchatLogService.getVRChaLogInfoByLogFilePathList,
+      vrchatLogService.getVRChaLogInfoByLogFilePathListWithPartialSuccess,
     ).mockImplementation(async (paths) => {
       // パスにlegacyPathが含まれていることを確認するためのカスタムモック
       expect(paths.some((p) => p.value === legacyPath)).toBe(true);
-      return neverthrow.ok([]);
+      return {
+        data: [],
+        errors: [],
+        totalProcessed: paths.length,
+        successCount: paths.length,
+        errorCount: 0,
+      };
     });
 
     try {
@@ -211,9 +228,15 @@ describe('loadLogInfoIndexFromVRChatLog', () => {
 
     // getVRChaLogInfoByLogFilePathListのモックをリセット
     vi.mocked(
-      vrchatLogService.getVRChaLogInfoByLogFilePathList,
+      vrchatLogService.getVRChaLogInfoByLogFilePathListWithPartialSuccess,
     ).mockImplementation(async () => {
-      return neverthrow.ok([]);
+      return {
+        data: [],
+        errors: [],
+        totalProcessed: 0,
+        successCount: 0,
+        errorCount: 0,
+      };
     });
 
     // テスト用にgetLogStoreFilePathsInRangeの実装を修正してパスを記録
@@ -298,9 +321,15 @@ describe('loadLogInfoIndexFromVRChatLog', () => {
 
     // getVRChaLogInfoByLogFilePathListのモックをリセット
     vi.mocked(
-      vrchatLogService.getVRChaLogInfoByLogFilePathList,
+      vrchatLogService.getVRChaLogInfoByLogFilePathListWithPartialSuccess,
     ).mockImplementation(async () => {
-      return neverthrow.ok([]);
+      return {
+        data: [],
+        errors: [],
+        totalProcessed: 0,
+        successCount: 0,
+        errorCount: 0,
+      };
     });
 
     // テスト用にgetLogStoreFilePathsInRangeの実装を修正してパスを記録
@@ -398,8 +427,14 @@ describe('_getLogStoreFilePaths behavior within loadLogInfoIndexFromVRChatLog', 
     ]);
     // getVRChaLogInfoByLogFilePathList は空の成功結果を返すように設定
     vi.mocked(
-      vrchatLogService.getVRChaLogInfoByLogFilePathList,
-    ).mockResolvedValue(neverthrow.ok([]));
+      vrchatLogService.getVRChaLogInfoByLogFilePathListWithPartialSuccess,
+    ).mockResolvedValue({
+      data: [],
+      errors: [],
+      totalProcessed: 0,
+      successCount: 0,
+      errorCount: 0,
+    });
     // 写真関連のモックも設定（必要に応じて）
     vi.mocked(vrchatPhotoService.getVRChatPhotoDirPath).mockResolvedValue(
       VRChatPhotoDirPathSchema.parse('/mock/photos'),
@@ -436,7 +471,7 @@ describe('_getLogStoreFilePaths behavior within loadLogInfoIndexFromVRChatLog', 
 
       // getVRChaLogInfoByLogFilePathList に渡されるパスを確認
       expect(
-        vrchatLogService.getVRChaLogInfoByLogFilePathList,
+        vrchatLogService.getVRChaLogInfoByLogFilePathListWithPartialSuccess,
       ).toHaveBeenCalledWith([rangeLogPath1, rangeLogPath2]);
     } finally {
       vi.useRealTimers();
@@ -469,7 +504,7 @@ describe('_getLogStoreFilePaths behavior within loadLogInfoIndexFromVRChatLog', 
 
       // getVRChaLogInfoByLogFilePathList に渡されるパスを確認 (legacy + range)
       expect(
-        vrchatLogService.getVRChaLogInfoByLogFilePathList,
+        vrchatLogService.getVRChaLogInfoByLogFilePathListWithPartialSuccess,
       ).toHaveBeenCalledWith([legacyLogPath, rangeLogPath1, rangeLogPath2]);
     } finally {
       vi.useRealTimers();
@@ -502,7 +537,7 @@ describe('_getLogStoreFilePaths behavior within loadLogInfoIndexFromVRChatLog', 
 
       // getVRChaLogInfoByLogFilePathList に渡されるパスを確認 (range のみ)
       expect(
-        vrchatLogService.getVRChaLogInfoByLogFilePathList,
+        vrchatLogService.getVRChaLogInfoByLogFilePathListWithPartialSuccess,
       ).toHaveBeenCalledWith([rangeLogPath1, rangeLogPath2]);
     } finally {
       vi.useRealTimers();
@@ -549,7 +584,7 @@ describe('_getLogStoreFilePaths behavior within loadLogInfoIndexFromVRChatLog', 
 
       // getVRChaLogInfoByLogFilePathList に渡されるパスを確認 (range のみ)
       expect(
-        vrchatLogService.getVRChaLogInfoByLogFilePathList,
+        vrchatLogService.getVRChaLogInfoByLogFilePathListWithPartialSuccess,
       ).toHaveBeenCalledWith([rangeLogPath1, rangeLogPath2]); // モックの rangeLogPath が渡される
     } finally {
       vi.useRealTimers();

--- a/electron/module/logInfo/service.ts
+++ b/electron/module/logInfo/service.ts
@@ -187,21 +187,39 @@ export async function loadLogInfoIndexFromVRChatLog({
     )}`,
   );
 
-  // 3. ログファイルからログ情報を取得
+  // 3. ログファイルからログ情報を取得（部分的な成功を許容）
   const getLogInfoStartTime = performance.now();
   const logInfoListFromLogFile =
-    await vrchatLogService.getVRChaLogInfoByLogFilePathList(logStoreFilePaths);
+    await vrchatLogService.getVRChaLogInfoByLogFilePathListWithPartialSuccess(
+      logStoreFilePaths,
+    );
   const getLogInfoEndTime = performance.now();
   logger.debug(
     `Get VRChat log info from log files took ${
       getLogInfoEndTime - getLogInfoStartTime
     } ms`,
   );
-  if (logInfoListFromLogFile.isErr()) {
-    return neverthrow.err(logInfoListFromLogFile.error);
+
+  // エラーがあった場合は警告を出力
+  if (logInfoListFromLogFile.errorCount > 0) {
+    logger.warn(
+      `Failed to process ${logInfoListFromLogFile.errorCount} log files out of ${logInfoListFromLogFile.totalProcessed}`,
+      logInfoListFromLogFile.errors.map((e) => ({
+        path: e.path,
+        code: e.error.code,
+      })),
+    );
   }
 
-  const logInfoList = logInfoListFromLogFile.value;
+  // 成功したログが1つもない場合のみエラーを返す
+  if (
+    logInfoListFromLogFile.successCount === 0 &&
+    logInfoListFromLogFile.errorCount > 0
+  ) {
+    return neverthrow.err(logInfoListFromLogFile.errors[0].error);
+  }
+
+  const logInfoList = logInfoListFromLogFile.data;
 
   const filterLogsStartTime = performance.now();
   const newLogs = await match(excludeOldLogLoad)

--- a/electron/module/logSync/logSyncController.ts
+++ b/electron/module/logSync/logSyncController.ts
@@ -1,9 +1,5 @@
 import z from 'zod';
-import {
-  ERROR_CATEGORIES,
-  ERROR_CODES,
-  UserFacingError,
-} from '../../lib/errors';
+import { handleVRChatLogError } from '../../lib/errorHelpers';
 import { procedure, router as trpcRouter } from '../../trpc';
 import { LOG_SYNC_MODE, type LogSyncMode, syncLogs } from './service';
 
@@ -31,18 +27,8 @@ export const logSyncRouter = () => {
       .mutation(async ({ input }) => {
         const result = await syncLogs(input.mode as LogSyncMode);
 
-        if (result.isErr()) {
-          throw UserFacingError.withStructuredInfo({
-            code: ERROR_CODES.UNKNOWN,
-            category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-            message: 'Log sync failed',
-            userMessage: `ログ同期に失敗しました: ${result.error.code}`,
-            cause:
-              result.error instanceof Error
-                ? result.error
-                : new Error(String(result.error)),
-          });
-        }
+        // VRChatLogFileErrorを適切なUserFacingErrorに変換
+        handleVRChatLogError(result);
 
         return true;
       }),

--- a/electron/module/vrchatLog/error.ts
+++ b/electron/module/vrchatLog/error.ts
@@ -17,7 +17,12 @@ type Code =
 export class VRChatLogFileError extends Error {
   code: Code | string;
 
-  constructor(codeOrError: Code | (Error & { code: string })) {
+  constructor(
+    codeOrError:
+      | Code
+      | (Error & { code: string })
+      | { code: string; message?: string },
+  ) {
     const result = match(codeOrError)
       .with(P.string, (code) => ({
         message: code,
@@ -28,6 +33,11 @@ export class VRChatLogFileError extends Error {
         message: error.message,
         code: error.code,
         stack: error.stack,
+      }))
+      .with({ code: P.string }, (obj) => ({
+        message: obj.message || obj.code,
+        code: obj.code,
+        stack: undefined,
       }))
       .otherwise(() => ({
         message: 'UNKNOWN',

--- a/electron/module/vrchatLog/fileHandlers/index.ts
+++ b/electron/module/vrchatLog/fileHandlers/index.ts
@@ -6,6 +6,7 @@
 export {
   getLogLinesFromLogFile,
   getLogLinesByLogFilePathList,
+  getLogLinesByLogFilePathListWithPartialSuccess,
   getLogLinesByLogFilePathListStreaming,
 } from './logFileReader';
 

--- a/electron/module/vrchatLog/types/partialSuccess.ts
+++ b/electron/module/vrchatLog/types/partialSuccess.ts
@@ -1,0 +1,48 @@
+/**
+ * 部分的な成功を表す結果型
+ * エラーが発生しても処理を継続し、成功した部分のデータとエラーの両方を返す
+ */
+export interface PartialSuccessResult<T, E> {
+  /**
+   * 成功したデータ
+   */
+  data: T;
+
+  /**
+   * 処理中に発生したエラーの配列
+   * 空の場合は全て成功
+   */
+  errors: E[];
+
+  /**
+   * 処理したアイテムの総数
+   */
+  totalProcessed: number;
+
+  /**
+   * 成功したアイテムの数
+   */
+  successCount: number;
+
+  /**
+   * 失敗したアイテムの数
+   */
+  errorCount: number;
+}
+
+/**
+ * PartialSuccessResultを作成するヘルパー関数
+ */
+export function createPartialSuccessResult<T, E>(
+  data: T,
+  errors: E[],
+  totalProcessed: number,
+): PartialSuccessResult<T, E> {
+  return {
+    data,
+    errors,
+    totalProcessed,
+    successCount: totalProcessed - errors.length,
+    errorCount: errors.length,
+  };
+}


### PR DESCRIPTION
## 概要
logLoad処理でエラーが発生しても処理全体を止めずに継続できるように改善しました。
一部のログファイルでエラーが発生しても、他のファイルの処理を継続し、成功した部分のデータを返すようになります。

## 関連Issue
Fixes #549

## 変更内容
### 1. PartialSuccessResult型の導入
- 成功したデータとエラー情報を両方返却可能な型を定義
- 処理の統計情報（総数、成功数、エラー数）も含む

### 2. 新しい関数の追加
- `getLogLinesByLogFilePathListWithPartialSuccess`: ログファイル読み込みで部分的成功を許容
- `getVRChaLogInfoByLogFilePathListWithPartialSuccess`: ログ情報取得で部分的成功を許容

### 3. エラーハンドリングの改善
- `loadLogInfoIndexFromVRChatLog`でPartialSuccessResultを使用
- エラーが発生してもログに警告を出力して処理を継続
- 全てのファイルで失敗した場合のみエラーを返す

### 4. VRChatLogFileError用のエラーマッピング
- `LOG_FILE_NOT_FOUND` → `FILE_NOT_FOUND` (警告レベル)
- `LOG_FILE_DIR_NOT_FOUND` → `SETUP_REQUIRED` (初期設定)
- `LOG_*_CREATE_FAILED` → `PERMISSION_DENIED` (重大エラー)
- 適切なユーザー向けメッセージを提供

## テスト
- 既存のテストが全て成功することを確認
- モックをPartialSuccessResultに対応するよう更新

## 影響範囲
- ログ読み込み処理のエラーハンドリングが改善
- 一部のログファイルでエラーが発生しても、アプリケーションが継続動作可能に

🤖 Generated with [Claude Code](https://claude.ai/code)