### PR TITLE
feat: improve instance type display with confidence-based detection

### DIFF
--- a/electron/module/vrchatLog/model.ts
+++ b/electron/module/vrchatLog/model.ts
@@ -131,6 +131,11 @@ class VRChatWorldInstanceId extends BaseValueObject<
 
     const typePart = parts[1];
 
+    // 空のtypePartの場合はnullを返す
+    if (typePart === '') {
+      return null;
+    }
+
     // インスタンスタイプを判定
     if (typePart.startsWith('friends(')) return 'friends';
     if (typePart.startsWith('hidden(')) return 'friends+';
@@ -139,7 +144,7 @@ class VRChatWorldInstanceId extends BaseValueObject<
     if (typePart.startsWith('groupPublic(')) return 'group-public';
 
     // リージョン情報のみの場合はPublic
-    if (typePart.match(/^[a-z]{2}(\([a-z0-9]+\))?$/)) return 'public';
+    if (typePart.match(/^[a-z]{2,3}(\([a-z0-9]+\))?$/)) return 'public';
 
     // その他の場合
     return 'unknown';

--- a/src/v2/components/LocationGroupHeader/index.tsx
+++ b/src/v2/components/LocationGroupHeader/index.tsx
@@ -17,6 +17,7 @@ import { useI18n } from '../../i18n/store';
 import {
   getInstanceTypeColor,
   getInstanceTypeLabel,
+  shouldShowInstanceTypeBadge,
 } from '../../utils/instanceTypeUtils';
 import { PlatformBadge } from './PlatformBadge';
 import { type Player, PlayerList } from './PlayerList';
@@ -313,15 +314,16 @@ export const LocationGroupHeader = ({
                     />
                     {formattedDate}
                   </div>
-                  {worldInstanceId && getInstanceTypeLabel(worldInstanceId) && (
-                    <div
-                      className={`flex items-center text-xs font-medium px-2.5 py-1 rounded-full backdrop-blur-sm border transition-all duration-300 ${getInstanceTypeColor(
-                        worldInstanceId,
-                      )}`}
-                    >
-                      {getInstanceTypeLabel(worldInstanceId)}
-                    </div>
-                  )}
+                  {worldInstanceId &&
+                    shouldShowInstanceTypeBadge(worldInstanceId) && (
+                      <div
+                        className={`flex items-center text-xs font-medium px-2.5 py-1 rounded-full backdrop-blur-sm border transition-all duration-300 ${getInstanceTypeColor(
+                          worldInstanceId,
+                        )}`}
+                      >
+                        {getInstanceTypeLabel(worldInstanceId)}
+                      </div>
+                    )}
                   {details?.unityPackages &&
                     details.unityPackages.length > 0 && (
                       <div className="flex items-center gap-1.5">

--- a/src/v2/utils/__tests__/instanceTypeUtils.test.ts
+++ b/src/v2/utils/__tests__/instanceTypeUtils.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type InstanceTypeConfidence,
+  getInstanceType,
+  getInstanceTypeLabel,
+  getInstanceTypeWithConfidence,
+  shouldShowInstanceTypeBadge,
+} from '../instanceTypeUtils';
+
+describe('instanceTypeUtils', () => {
+  describe('getInstanceTypeWithConfidence', () => {
+    it('nullの場合は低信頼度でnullを返す', () => {
+      const result = getInstanceTypeWithConfidence(null);
+      expect(result).toEqual({ type: null, confidence: 'low' });
+    });
+
+    it('空文字の場合は低信頼度でnullを返す', () => {
+      const result = getInstanceTypeWithConfidence('');
+      expect(result).toEqual({ type: null, confidence: 'low' });
+    });
+
+    it('~がないインスタンスIDは高信頼度でpublicを返す', () => {
+      const result = getInstanceTypeWithConfidence('12345');
+      expect(result).toEqual({ type: 'public', confidence: 'high' });
+    });
+
+    it('~以降が存在しない場合は低信頼度でnullを返す', () => {
+      const result = getInstanceTypeWithConfidence('12345~');
+      expect(result).toEqual({ type: null, confidence: 'low' });
+    });
+
+    describe('既知のプライベートインスタンスパターン（高信頼度）', () => {
+      it('friendsインスタンスを高信頼度で判定する', () => {
+        const result = getInstanceTypeWithConfidence(
+          '12345~friends(usr_12345678-1234-1234-1234-123456789abc)',
+        );
+        expect(result).toEqual({ type: 'friends', confidence: 'high' });
+      });
+
+      it('friends+インスタンスを高信頼度で判定する', () => {
+        const result = getInstanceTypeWithConfidence(
+          '12345~hidden(usr_12345678-1234-1234-1234-123456789abc)',
+        );
+        expect(result).toEqual({ type: 'friends+', confidence: 'high' });
+      });
+
+      it('inviteインスタンスを高信頼度で判定する', () => {
+        const result = getInstanceTypeWithConfidence(
+          '12345~private(usr_12345678-1234-1234-1234-123456789abc)',
+        );
+        expect(result).toEqual({ type: 'invite', confidence: 'high' });
+      });
+
+      it('groupインスタンスを高信頼度で判定する', () => {
+        const result = getInstanceTypeWithConfidence(
+          '12345~group(grp_12345678-1234-1234-1234-123456789abc)',
+        );
+        expect(result).toEqual({ type: 'group', confidence: 'high' });
+      });
+
+      it('group-publicインスタンスを高信頼度で判定する', () => {
+        const result = getInstanceTypeWithConfidence(
+          '12345~groupPublic(grp_12345678-1234-1234-1234-123456789abc)',
+        );
+        expect(result).toEqual({ type: 'group-public', confidence: 'high' });
+      });
+    });
+
+    describe('リージョン情報パターン（中信頼度）', () => {
+      it('2文字のリージョンコードを中信頼度でpublicと判定する', () => {
+        const result = getInstanceTypeWithConfidence('12345~jp');
+        expect(result).toEqual({ type: 'public', confidence: 'medium' });
+      });
+
+      it('3文字のリージョンコードを中信頼度でpublicと判定する', () => {
+        const result = getInstanceTypeWithConfidence('12345~usw');
+        expect(result).toEqual({ type: 'public', confidence: 'medium' });
+      });
+
+      it('リージョンコードとパラメータを中信頼度でpublicと判定する', () => {
+        const result = getInstanceTypeWithConfidence('12345~us(e)');
+        expect(result).toEqual({ type: 'public', confidence: 'medium' });
+      });
+
+      it('数字を含むリージョンパラメータを中信頼度でpublicと判定する', () => {
+        const result = getInstanceTypeWithConfidence('12345~jp(1234)');
+        expect(result).toEqual({ type: 'public', confidence: 'medium' });
+      });
+    });
+
+    describe('不明なパターン（低信頼度）', () => {
+      it('不明なタイプの場合は低信頼度でunknownを返す', () => {
+        const result = getInstanceTypeWithConfidence('12345~something');
+        expect(result).toEqual({ type: 'unknown', confidence: 'low' });
+      });
+
+      it('長いリージョンコードは低信頼度でunknownを返す', () => {
+        const result = getInstanceTypeWithConfidence('12345~toolong');
+        expect(result).toEqual({ type: 'unknown', confidence: 'low' });
+      });
+
+      it('無効なリージョンパラメータは低信頼度でunknownを返す', () => {
+        const result = getInstanceTypeWithConfidence('12345~us(invalid!)');
+        expect(result).toEqual({ type: 'unknown', confidence: 'low' });
+      });
+    });
+  });
+
+  describe('shouldShowInstanceTypeBadge', () => {
+    it('nullの場合はfalseを返す', () => {
+      expect(shouldShowInstanceTypeBadge(null)).toBe(false);
+    });
+
+    it('高信頼度の場合はtrueを返す', () => {
+      expect(shouldShowInstanceTypeBadge('12345')).toBe(true);
+      expect(shouldShowInstanceTypeBadge('12345~friends(usr_123)')).toBe(true);
+    });
+
+    it('中信頼度の場合はtrueを返す', () => {
+      expect(shouldShowInstanceTypeBadge('12345~jp')).toBe(true);
+      expect(shouldShowInstanceTypeBadge('12345~us(e)')).toBe(true);
+    });
+
+    it('低信頼度の場合はfalseを返す', () => {
+      expect(shouldShowInstanceTypeBadge('12345~something')).toBe(false);
+      expect(shouldShowInstanceTypeBadge('12345~toolong')).toBe(false);
+    });
+  });
+
+  describe('getInstanceType（後方互換性）', () => {
+    it('従来の動作を維持している', () => {
+      expect(getInstanceType('12345')).toBe('public');
+      expect(getInstanceType('12345~friends(usr_123)')).toBe('friends');
+      expect(getInstanceType('12345~jp')).toBe('public');
+      expect(getInstanceType('12345~something')).toBe('unknown');
+      expect(getInstanceType(null)).toBe(null);
+    });
+  });
+
+  describe('getInstanceTypeLabel', () => {
+    it('各インスタンスタイプに対応する正しいラベルを返す', () => {
+      expect(getInstanceTypeLabel('12345')).toBe('Public');
+      expect(getInstanceTypeLabel('12345~friends(usr_123)')).toBe('Friends');
+      expect(getInstanceTypeLabel('12345~hidden(usr_123)')).toBe('Friends+');
+      expect(getInstanceTypeLabel('12345~private(usr_123)')).toBe('Invite');
+      expect(getInstanceTypeLabel('12345~group(grp_123)')).toBe('Group');
+      expect(getInstanceTypeLabel('12345~groupPublic(grp_123)')).toBe(
+        'Group Public',
+      );
+      expect(getInstanceTypeLabel('12345~something')).toBe('Unknown');
+      expect(getInstanceTypeLabel(null)).toBe('');
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('空の~セクションは低信頼度でnullを返す', () => {
+      const result = getInstanceTypeWithConfidence('12345~');
+      expect(result).toEqual({ type: null, confidence: 'low' });
+    });
+
+    it('複数の~が含まれる場合は最初の~以降を解析する', () => {
+      const result = getInstanceTypeWithConfidence(
+        '12345~friends(usr_123)~extra',
+      );
+      expect(result).toEqual({ type: 'friends', confidence: 'high' });
+    });
+
+    it('大文字のリージョンコードは低信頼度でunknownを返す', () => {
+      const result = getInstanceTypeWithConfidence('12345~JP');
+      expect(result).toEqual({ type: 'unknown', confidence: 'low' });
+    });
+  });
+});

--- a/src/v2/utils/instanceTypeUtils.ts
+++ b/src/v2/utils/instanceTypeUtils.ts
@@ -3,38 +3,75 @@
  */
 
 /**
- * インスタンスIDからインスタンスタイプを取得する
- * @param instanceId インスタンスID文字列
- * @returns インスタンスタイプ
+ * インスタンスタイプの信頼度レベル
  */
-export const getInstanceType = (instanceId: string | null): string | null => {
-  if (!instanceId) return null;
+export type InstanceTypeConfidence = 'high' | 'medium' | 'low';
 
-  // インスタンスIDに~が含まれていない場合はPublicインスタンス
+/**
+ * インスタンスタイプと信頼度を含む結果
+ */
+export interface InstanceTypeResult {
+  type: string | null;
+  confidence: InstanceTypeConfidence;
+}
+
+/**
+ * インスタンスIDからインスタンスタイプと信頼度を取得する
+ * @param instanceId インスタンスID文字列
+ * @returns インスタンスタイプと信頼度
+ */
+export const getInstanceTypeWithConfidence = (
+  instanceId: string | null,
+): InstanceTypeResult => {
+  if (!instanceId) return { type: null, confidence: 'low' };
+
+  // インスタンスIDに~が含まれていない場合はPublicインスタンス（高信頼度）
   if (!instanceId.includes('~')) {
-    return 'public';
+    return { type: 'public', confidence: 'high' };
   }
 
   // ~以降の部分を取得
   const parts = instanceId.split('~');
   if (parts.length < 2) {
-    return null;
+    return { type: null, confidence: 'low' };
   }
 
   const typePart = parts[1];
 
-  // インスタンスタイプを判定
-  if (typePart.startsWith('friends(')) return 'friends';
-  if (typePart.startsWith('hidden(')) return 'friends+';
-  if (typePart.startsWith('private(')) return 'invite';
-  if (typePart.startsWith('group(')) return 'group';
-  if (typePart.startsWith('groupPublic(')) return 'group-public';
+  // 空のtypePartの場合は低信頼度でnullを返す
+  if (typePart === '') {
+    return { type: null, confidence: 'low' };
+  }
 
-  // リージョン情報のみの場合はPublic
-  if (typePart.match(/^[a-z]{2}(\([a-z0-9]+\))?$/)) return 'public';
+  // 既知のプライベートインスタンスパターン（高信頼度）
+  if (typePart.startsWith('friends('))
+    return { type: 'friends', confidence: 'high' };
+  if (typePart.startsWith('hidden('))
+    return { type: 'friends+', confidence: 'high' };
+  if (typePart.startsWith('private('))
+    return { type: 'invite', confidence: 'high' };
+  if (typePart.startsWith('group('))
+    return { type: 'group', confidence: 'high' };
+  if (typePart.startsWith('groupPublic('))
+    return { type: 'group-public', confidence: 'high' };
 
-  // その他の場合
-  return 'unknown';
+  // リージョン情報のみの場合はPublic（中信頼度）
+  if (typePart.match(/^[a-z]{2,3}(\([a-z0-9]+\))?$/)) {
+    return { type: 'public', confidence: 'medium' };
+  }
+
+  // その他の場合（低信頼度）
+  return { type: 'unknown', confidence: 'low' };
+};
+
+/**
+ * インスタンスIDからインスタンスタイプを取得する
+ * @param instanceId インスタンスID文字列
+ * @returns インスタンスタイプ
+ */
+export const getInstanceType = (instanceId: string | null): string | null => {
+  const result = getInstanceTypeWithConfidence(instanceId);
+  return result.type;
 };
 
 /**
@@ -89,4 +126,17 @@ export const getInstanceTypeColor = (instanceId: string | null): string => {
     default:
       return 'bg-gray-500/20 text-gray-700 dark:text-gray-300 border-gray-500/30';
   }
+};
+
+/**
+ * インスタンスタイプバッジを表示するかどうかを判定する
+ * @param instanceId インスタンスID文字列
+ * @returns バッジを表示するかどうか
+ */
+export const shouldShowInstanceTypeBadge = (
+  instanceId: string | null,
+): boolean => {
+  const result = getInstanceTypeWithConfidence(instanceId);
+  // 高信頼度または中信頼度の場合のみバッジを表示
+  return result.confidence === 'high' || result.confidence === 'medium';
 };


### PR DESCRIPTION
**Summary**

- Implement confidence-based instance type detection to distinguish between truly unknown and public instances
- Hide low confidence (unknown) instance type badges in UI
- Improve region code detection to support 2-3 character codes
- Add comprehensive test coverage for new functionality
- Maintain backward compatibility with existing code

**Fixes #552**

**Test Plan**

- [x] All frontend tests passing (25/25)
- [x] All backend tests passing (30/30)
- [x] Type checking passed
- [x] Linting passed
- [x] Manual testing of UI changes needed

Generated with [Claude Code](https://claude.ai/code)