### PR TITLE
style: lighten glass-panel shadow for better visual weight

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -230,8 +230,8 @@
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
     box-shadow: 
-      0 4px 16px rgba(31, 38, 135, 0.15),
-      inset 0 1px 0 rgba(255, 255, 255, 0.05);
+      0 2px 8px rgba(0, 0, 0, 0.08),
+      inset 0 1px 0 rgba(255, 255, 255, 0.03);
   }
   
   .glass-card {


### PR DESCRIPTION
## Summary
- Reduce shadow blur from 16px to 8px for lighter appearance
- Change from blue-tinted shadow to neutral black with lower opacity  
- Decrease inset highlight opacity for subtler glass effect

Addresses visual heaviness in LocationGroupHeader and other glass-panel components.

## Test plan
- [ ] Verify LocationGroupHeader appears visually lighter
- [ ] Check other glass-panel components maintain appropriate styling
- [ ] Test in both light and dark modes

🤖 Generated with [Claude Code](https://claude.ai/code)