### PR TITLE
fix: replace wildcard pattern in sentry:sourcemaps script with explicit script names

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lint:fix": "run-s \"lint:fix:biome\" lint:type-check",
     "lint:fix:biome": "biome check --apply-unsafe .",
     "lint:fix:tsc": "run-s \"lint:fix:biome\" lint:type-check:tsc",
-    "sentry:sourcemaps": "run-s sentry:sourcemaps:*",
+    "sentry:sourcemaps": "run-s sentry:sourcemaps:electron sentry:sourcemaps:vite",
     "sentry:sourcemaps:electron": "sentry-cli sourcemaps inject --org $SENTRY_ORG --project $SENTRY_PROJECT --release $SENTRY_RELEASE ./main && sentry-cli sourcemaps upload --org $SENTRY_ORG --project $SENTRY_PROJECT --release $SENTRY_RELEASE ./main",
     "sentry:sourcemaps:vite": "sentry-cli sourcemaps inject --org $SENTRY_ORG --project $SENTRY_PROJECT --release $SENTRY_RELEASE ./src/out && sentry-cli sourcemaps upload --org $SENTRY_ORG --project $SENTRY_PROJECT --release $SENTRY_RELEASE ./src/out",
     "knip": "knip --config knip.config.ts"


### PR DESCRIPTION
Fixes #569

The `run-s sentry:sourcemaps:*` command was failing to find matching scripts. Changed to explicitly list the two scripts:
- sentry:sourcemaps:electron
- sentry:sourcemaps:vite

This ensures reliable execution of sourcemap uploads in CI/CD pipeline.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the script for handling sourcemaps to improve reliability when running related tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->