### PR TITLE
fix: improve light mode contrast by making foreground elements brighter

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -50,10 +50,10 @@
  
     --radius: 0.75rem;
 
-    /* Arc Browser style subtle gradient background */
-    --gradient-start: 220 15% 98%;
-    --gradient-middle: 225 12% 96%;
-    --gradient-end: 230 10% 94%;
+    /* Arc Browser style subtle gradient background - reduced brightness for better contrast */
+    --gradient-start: 220 15% 92%;
+    --gradient-middle: 225 12% 90%;
+    --gradient-end: 230 10% 88%;
     
     /* Glass effect backdrop */
     --glass-bg: 0 0% 100% / 0.1;

--- a/src/v2/components/LocationGroupHeader/index.tsx
+++ b/src/v2/components/LocationGroupHeader/index.tsx
@@ -240,10 +240,10 @@ export const LocationGroupHeader = ({
                   filter: 'blur(26px) saturate(120%) brightness(0.9)',
                 }}
               />
-              <div className="absolute inset-0 bg-white/40 dark:bg-gray-900/50 backdrop-blur-[1px] group-hover/card:backdrop-blur-[2px] transition-all duration-500" />
+              <div className="absolute inset-0 bg-white/70 dark:bg-gray-900/50 backdrop-blur-[1px] group-hover/card:backdrop-blur-[2px] transition-all duration-500" />
               <div className="absolute inset-0">
-                <div className="absolute inset-0 bg-gradient-to-r from-white/50 to-white/30 dark:from-gray-900/30 dark:to-gray-900/10 mix-blend-overlay" />
-                <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_120%,rgba(255,255,255,0.4),rgba(255,255,255,0.2)_70%)] dark:bg-[radial-gradient(circle_at_50%_120%,rgba(17,24,39,0.4),rgba(17,24,39,0.2)_70%)]" />
+                <div className="absolute inset-0 bg-gradient-to-r from-white/60 to-white/40 dark:from-gray-900/30 dark:to-gray-900/10 mix-blend-overlay" />
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_120%,rgba(255,255,255,0.6),rgba(255,255,255,0.3)_70%)] dark:bg-[radial-gradient(circle_at_50%_120%,rgba(17,24,39,0.4),rgba(17,24,39,0.2)_70%)]" />
               </div>
             </>
           )}


### PR DESCRIPTION
Fixes #572

Improved light mode visual hierarchy by making foreground elements brighter than the background.

## Changes
- Reduced light mode background brightness for better contrast
- Increased LocationGroupHeader frosted glass opacity in light mode

## Before
Frosted glass location group headers appeared darker than the bright white background, creating incorrect visual hierarchy.

## After
Foreground elements now appear brighter than the background, creating proper contrast and visual depth.

Generated with [Claude Code](https://claude.ai/code)