### PR TITLE
fix: 右クリック写真コピーで全選択写真をコピーできない問題を修正

### DIFF
--- a/src/assets/licenses.json
+++ b/src/assets/licenses.json
@@ -175,11 +175,11 @@
     "path": "node_modules/@electron/get",
     "licenseFile": "node_modules/@electron/get/LICENSE"
   },
-  "@esbuild/linux-arm64@0.21.5": {
+  "@esbuild/linux-x64@0.21.5": {
     "licenses": "MIT",
     "repository": "https://github.com/evanw/esbuild",
-    "path": "node_modules/@esbuild/linux-arm64",
-    "licenseFile": "node_modules/@esbuild/linux-arm64/README.md"
+    "path": "node_modules/@esbuild/linux-x64",
+    "licenseFile": "node_modules/@esbuild/linux-x64/README.md"
   },
   "@floating-ui/core@1.7.1": {
     "licenses": "MIT",
@@ -217,21 +217,21 @@
     "path": "node_modules/@gar/promisify",
     "licenseFile": "node_modules/@gar/promisify/LICENSE.md"
   },
-  "@img/sharp-libvips-linux-arm64@1.0.2": {
+  "@img/sharp-libvips-linux-x64@1.0.2": {
     "licenses": "LGPL-3.0-or-later",
     "repository": "https://github.com/lovell/sharp-libvips",
     "publisher": "Lovell Fuller",
     "email": "npm@lovell.info",
-    "path": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm64",
-    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm64/README.md"
+    "path": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-x64",
+    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-x64/README.md"
   },
-  "@img/sharp-linux-arm64@0.33.3": {
+  "@img/sharp-linux-x64@0.33.3": {
     "licenses": "Apache-2.0",
     "repository": "https://github.com/lovell/sharp",
     "publisher": "Lovell Fuller",
     "email": "npm@lovell.info",
-    "path": "node_modules/sharp/node_modules/@img/sharp-linux-arm64",
-    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-linux-arm64/LICENSE"
+    "path": "node_modules/sharp/node_modules/@img/sharp-linux-x64",
+    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-linux-x64/LICENSE"
   },
   "@isaacs/cliui@8.0.2": {
     "licenses": "ISC",
@@ -807,12 +807,12 @@
     "path": "node_modules/@radix-ui/rect",
     "licenseFile": "node_modules/@radix-ui/rect/README.md"
   },
-  "@rollup/rollup-linux-arm64-gnu@4.43.0": {
+  "@rollup/rollup-linux-x64-gnu@4.43.0": {
     "licenses": "MIT",
     "repository": "https://github.com/rollup/rollup",
     "publisher": "Lukas Taegert-Atkinson",
-    "path": "node_modules/@rollup/rollup-linux-arm64-gnu",
-    "licenseFile": "node_modules/@rollup/rollup-linux-arm64-gnu/README.md"
+    "path": "node_modules/@rollup/rollup-linux-x64-gnu",
+    "licenseFile": "node_modules/@rollup/rollup-linux-x64-gnu/README.md"
   },
   "@sentry-internal/browser-utils@9.26.0": {
     "licenses": "MIT",
@@ -863,17 +863,17 @@
     "path": "node_modules/@sentry/bundler-plugin-core",
     "licenseFile": "node_modules/@sentry/bundler-plugin-core/LICENSE"
   },
-  "@sentry/cli-linux-arm64@2.42.2": {
+  "@sentry/cli-linux-x64@2.42.2": {
     "licenses": "BSD-3-Clause",
     "repository": "https://github.com/getsentry/sentry-cli",
-    "path": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-arm64",
-    "licenseFile": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-arm64/README.md"
+    "path": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-x64",
+    "licenseFile": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-x64/README.md"
   },
-  "@sentry/cli-linux-arm64@2.46.0": {
+  "@sentry/cli-linux-x64@2.46.0": {
     "licenses": "BSD-3-Clause",
     "repository": "https://github.com/getsentry/sentry-cli",
-    "path": "node_modules/@sentry/cli-linux-arm64",
-    "licenseFile": "node_modules/@sentry/cli-linux-arm64/README.md"
+    "path": "node_modules/@sentry/cli-linux-x64",
+    "licenseFile": "node_modules/@sentry/cli-linux-x64/README.md"
   },
   "@sentry/cli@2.42.2": {
     "licenses": "BSD-3-Clause",
@@ -1577,11 +1577,11 @@
     "path": "node_modules/clean-stack",
     "licenseFile": "node_modules/clean-stack/license"
   },
-  "clip-filepaths-linux-arm64-gnu@0.2.0": {
+  "clip-filepaths-linux-x64-gnu@0.2.0": {
     "licenses": "MIT",
     "repository": "https://github.com/tktcorporation/clip-filepaths",
-    "path": "node_modules/clip-filepaths-linux-arm64-gnu",
-    "licenseFile": "node_modules/clip-filepaths-linux-arm64-gnu/README.md"
+    "path": "node_modules/clip-filepaths-linux-x64-gnu",
+    "licenseFile": "node_modules/clip-filepaths-linux-x64-gnu/README.md"
   },
   "clip-filepaths@0.2.0": {
     "licenses": "MIT",
@@ -2781,11 +2781,11 @@
     "path": "node_modules/lazy-val",
     "licenseFile": "node_modules/lazy-val/readme.md"
   },
-  "lightningcss-linux-arm64-gnu@1.30.1": {
+  "lightningcss-linux-x64-gnu@1.30.1": {
     "licenses": "MPL-2.0",
     "repository": "https://github.com/parcel-bundler/lightningcss",
-    "path": "node_modules/lightningcss-linux-arm64-gnu",
-    "licenseFile": "node_modules/lightningcss-linux-arm64-gnu/LICENSE"
+    "path": "node_modules/lightningcss-linux-x64-gnu",
+    "licenseFile": "node_modules/lightningcss-linux-x64-gnu/LICENSE"
   },
   "lightningcss@1.30.1": {
     "licenses": "MPL-2.0",

--- a/src/v2/components/PhotoCard.tsx
+++ b/src/v2/components/PhotoCard.tsx
@@ -40,6 +40,8 @@ interface PhotoCardProps {
   setIsMultiSelectMode: (value: boolean) => void;
   /** 計算された表示高さ (オプション) */
   displayHeight?: number;
+  /** 選択された写真をコピーする関数（全グループにアクセス可能） */
+  onCopySelected?: () => void;
 }
 
 /**
@@ -56,6 +58,7 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
     isMultiSelectMode,
     setIsMultiSelectMode,
     displayHeight,
+    onCopySelected,
   }) => {
     const { t } = useI18n();
     const elementRef = useRef<HTMLDivElement>(null);
@@ -99,7 +102,11 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
     /** コンテキストメニュー: 写真パスコピー (単一/複数対応) */
     const handleCopyPhotoData = (e: React.MouseEvent) => {
       e.stopPropagation();
-      if (selectedPhotos.size > 1) {
+      if (selectedPhotos.size > 1 && onCopySelected) {
+        // 複数選択時は親コンポーネントのコピー機能を使用（全グループにアクセス可能）
+        onCopySelected();
+      } else if (selectedPhotos.size > 1) {
+        // フォールバック：同じグループ内の写真のみコピー（後方互換性のため）
         const pathsToCopy = Array.from(selectedPhotos)
           .map((id) => {
             const p = photos.find((p) => String(p.id) === id);

--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -295,6 +295,7 @@ const GalleryContent = memo(
                           setSelectedPhotos={setSelectedPhotos}
                           isMultiSelectMode={isMultiSelectMode}
                           setIsMultiSelectMode={setIsMultiSelectMode}
+                          onCopySelected={galleryData?.onCopySelected}
                         />
                       </div>
                     )}

--- a/src/v2/components/PhotoGrid.tsx
+++ b/src/v2/components/PhotoGrid.tsx
@@ -21,6 +21,8 @@ interface PhotoGridProps {
   isMultiSelectMode: boolean;
   /** 複数選択モードの有効/無効を設定する関数 */
   setIsMultiSelectMode: (value: boolean) => void;
+  /** 選択された写真をコピーする関数（全グループにアクセス可能） */
+  onCopySelected?: () => void;
 }
 
 /**
@@ -61,6 +63,7 @@ export default function PhotoGrid({
   setSelectedPhotos,
   isMultiSelectMode,
   setIsMultiSelectMode,
+  onCopySelected,
 }: PhotoGridProps) {
   const { containerRef, containerWidth } = useContainerWidth();
   const calculator = useMemo(() => new JustifiedLayoutCalculator(), []);
@@ -104,6 +107,7 @@ export default function PhotoGrid({
                       isMultiSelectMode={isMultiSelectMode}
                       setIsMultiSelectMode={setIsMultiSelectMode}
                       displayHeight={photo.displayHeight}
+                      onCopySelected={onCopySelected}
                     />
                   </div>
                 );


### PR DESCRIPTION
複数の写真を選択して右クリックメニューからコピーした場合、
現在のグループの写真のみがコピーされ、他のグループで選択された
写真がコピーされない問題を修正しました。

Fixes #585

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional callback to handle copying multiple selected photos across all groups, allowing parent components to control this action.
* **Chores**
  * Updated license metadata to reference Linux x64 packages instead of Linux ARM64 packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->