### PR TITLE
fix: restrict platform display to Windows only in landing page

### DIFF
--- a/pages/src/components/Download.tsx
+++ b/pages/src/components/Download.tsx
@@ -87,10 +87,10 @@ function Download() {
           )}
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-4xl mx-auto my-12">
+        <div className="flex justify-center my-12">
           <a
             href={getDownloadLink('windows')}
-            className="bg-gray-50 dark:bg-gray-900 p-8 rounded-lg text-center no-underline text-gray-900 dark:text-gray-100 transition-all duration-250 border-2 border-transparent flex flex-col items-center hover:-translate-y-1 hover:shadow-lg hover:border-[#5865F2]"
+            className="bg-gray-50 dark:bg-gray-900 p-8 rounded-lg text-center no-underline text-gray-900 dark:text-gray-100 transition-all duration-250 border-2 border-transparent flex flex-col items-center hover:-translate-y-1 hover:shadow-lg hover:border-[#5865F2] max-w-sm"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -101,38 +101,6 @@ function Download() {
             </p>
             <span className="inline-block bg-[#5865F2] text-white px-6 py-2 rounded-full font-medium text-sm mt-auto">
               ダウンロード (.exe)
-            </span>
-          </a>
-
-          <a
-            href={getDownloadLink('mac')}
-            className="bg-gray-50 dark:bg-gray-900 p-8 rounded-lg text-center no-underline text-gray-900 dark:text-gray-100 transition-all duration-250 border-2 border-transparent flex flex-col items-center hover:-translate-y-1 hover:shadow-lg hover:border-[#5865F2]"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="text-5xl mb-4">🍎</div>
-            <h3 className="text-xl font-semibold mb-1">macOS</h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
-              macOS 10.15+
-            </p>
-            <span className="inline-block bg-[#5865F2] text-white px-6 py-2 rounded-full font-medium text-sm mt-auto">
-              ダウンロード (.dmg)
-            </span>
-          </a>
-
-          <a
-            href={getDownloadLink('linux')}
-            className="bg-gray-50 dark:bg-gray-900 p-8 rounded-lg text-center no-underline text-gray-900 dark:text-gray-100 transition-all duration-250 border-2 border-transparent flex flex-col items-center hover:-translate-y-1 hover:shadow-lg hover:border-[#5865F2]"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="text-5xl mb-4">🐧</div>
-            <h3 className="text-xl font-semibold mb-1">Linux</h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
-              AppImage形式
-            </p>
-            <span className="inline-block bg-[#5865F2] text-white px-6 py-2 rounded-full font-medium text-sm mt-auto">
-              ダウンロード (.AppImage)
             </span>
           </a>
         </div>


### PR DESCRIPTION
## Summary

Restrict platform display to Windows only in landing page while keeping cross-platform builds in release configuration.

## Changes
- Update landing page to show only Windows download option
- Keep cross-platform build configurations intact for releases

As requested in #582, this change only affects the user-facing documentation and landing page, not the actual build process.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Redesigned the downloads section to a centered, single-card layout.
  - Removed macOS and Linux download cards; only the Windows download option is displayed.
  - Applied a max-width to the Windows download card for improved readability.
  - Preserved existing content for the Windows card (icon, title, OS info, label).
  - Retained the “Other downloads” note with a link to GitHub releases for additional platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->