### PR TITLE
chore: ドキュメントの整理とXML検証ツールの追加

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -11,6 +11,7 @@ uv = "latest"
 # Node.js global packages
 "npm:@anthropic-ai/claude-code" = "latest"
 "npm:@antfu/ni" = "latest"
+"npm:fxp-cli" = "latest"
 
 
 [settings]
@@ -18,6 +19,9 @@ uv = "latest"
 experimental = true
 # Explicitly enable idiomatic version files for node
 idiomatic_version_file_enable_tools = ["node"]
+
+[tasks]
+"lint:xml" = "cat CLAUDE.md | fxp val"
 
 [hooks]
 postinstall = [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,276 +1,286 @@
-# CLAUDE.md
+<?xml version="1.0" encoding="UTF-8"?>
+<claude-instructions>
+  <description>This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.</description>
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+  <architecture>
+    <overview>Electron desktop app for organizing VRChat photos by automatically associating them with log files.</overview>
+    
+    <tech-stack>
+      <item>Electron</item>
+      <item>React 18</item>
+      <item>TypeScript</item>
+      <item>Vite</item>
+      <item>tRPC</item>
+      <item>SQLite/Sequelize</item>
+      <item>Tailwind/Radix UI</item>
+      <item>ts-pattern</item>
+      <item>neverthrow</item>
+    </tech-stack>
+    
+    <structure>
+      <directory path="/electron/">Main process (tRPC router in api.ts, business logic in /module/)</directory>
+      <directory path="/src/v2/">Renderer process (React components, hooks, i18n)</directory>
+    </structure>
+  </architecture>
 
-## High-Level Architecture
+  <environment>
+    <nodejs>20 LTS</nodejs>
+    <package-manager>Yarn 4 (npm禁止)</package-manager>
+  </environment>
 
-Electron desktop app for organizing VRChat photos by automatically associating them with log files.
+  <critical-guidelines>
+    <log-synchronization priority="critical" jp="データ整合性必須">
+      <execution-order strict="true">appendLoglines → loadLogInfo → cache invalidation</execution-order>
+      <violation-risk jp="違反すると写真が間違ったワールドに分類されます"/>
+      <usage>
+        <allowed>useLogSync hook (frontend) / syncLogs() service (backend)</allowed>
+        <forbidden>Call append/load functions individually</forbidden>
+      </usage>
+      <sync-modes>
+        <mode name="FULL">Complete processing (初回起動、設定更新時)</mode>
+        <mode name="INCREMENTAL">Delta processing (通常更新、バックグラウンド)</mode>
+      </sync-modes>
+      <reference>docs/log-sync-architecture.md</reference>
+    </log-synchronization>
 
-**Tech Stack**: Electron + React 18 + TypeScript + Vite + tRPC + SQLite/Sequelize + Tailwind/Radix UI + ts-pattern
+    <task-completion-process>
+      <step order="1">Code Implementation</step>
+      <step order="2">yarn lint:fix</step>
+      <step order="3">yarn lint</step>
+      <step order="4">yarn test</step>
+      <step order="5">Task Completion</step>
+    </task-completion-process>
+  </critical-guidelines>
 
-**Structure**:
-- `/electron/` - Main process (tRPC router in api.ts, business logic in /module/)
-- `/src/v2/` - Renderer process (React components, hooks, i18n)
+  <architectural-patterns>
+    <pattern name="tRPC Communication">
+      <description>All communication between Electron main and renderer processes goes through tRPC routers defined in electron/api.ts</description>
+    </pattern>
 
-## ⚠️ CRITICAL GUIDELINES
+    <pattern name="Error Handling" jp="型安全・構造化システム">
+      <layer name="Service">neverthrow Result pattern (Result&lt;T, E&gt;)</layer>
+      <layer name="tRPC">UserFacingError with structured info (code/category/userMessage)</layer>
+      <layer name="Frontend">parseErrorFromTRPC + Toast variant selection</layer>
+      
+      <structured-error-info>
+        <field name="code" description="FILE_NOT_FOUND, DATABASE_ERROR, etc."/>
+        <field name="category" description="ERROR_CATEGORIES enum値"/>
+        <field name="userMessage" description="ユーザー向けメッセージ"/>
+      </structured-error-info>
+      
+      <error-mapping>
+        <file>electron/lib/errorHelpers.ts</file>
+        <requirement>Result→UserFacingError bridging with ts-pattern</requirement>
+        <requirement>ALL mappings MUST have default case (prevent "予期しないエラー")</requirement>
+      </error-mapping>
+      
+      <frontend-processing>
+        <function>parseErrorFromTRPC()</function>
+        <function>getToastVariant(category) with ts-pattern</function>
+      </frontend-processing>
+      
+      <toast-variant-mapping>
+        <map category="FILE_NOT_FOUND" variant="warning" jp="準正常系"/>
+        <map category="VALIDATION_ERROR" variant="warning" jp="ユーザー入力問題"/>
+        <map category="SETUP_REQUIRED" variant="default" jp="初期設定"/>
+        <map category="PERMISSION_DENIED" variant="destructive" jp="システムエラー"/>
+        <map category="DATABASE_ERROR" variant="destructive" jp="重大エラー"/>
+        <map category="NETWORK_ERROR" variant="destructive" jp="重大エラー"/>
+      </toast-variant-mapping>
+    </pattern>
 
-### 🚨 Log Synchronization (データ整合性必須)
-**Execution Order**: `appendLoglines` → `loadLogInfo` → cache invalidation
-**違反すると写真が間違ったワールドに分類されます**
+    <pattern name="ts-pattern Usage" priority="critical" jp="型安全・表現力向上必須">
+      <mandatory>Replace ALL if statements with match() from ts-pattern</mandatory>
+      <priority-targets>
+        <target>Error handling conditionals</target>
+        <target>Enum/string literal comparisons</target>
+        <target>Type guards and instanceof checks</target>
+        <target>Nested if-else chains</target>
+      </priority-targets>
+      <example>
+        <![CDATA[
+        import { match, P } from 'ts-pattern';
+        
+        // Replace: if (error instanceof Error) return handleError(error);
+        return match(error)
+          .with(P.instanceOf(Error), (err) => handleError(err))
+          .otherwise((err) => { throw err; });
+        ]]>
+      </example>
+      <exceptions>
+        <exception>Simple boolean checks (if (isLoading))</exception>
+        <exception>Complex business logic conditions</exception>
+        <exception>Test assertions</exception>
+      </exceptions>
+      <benefits>Type inference, exhaustiveness checking, better readability</benefits>
+    </pattern>
 
-- ✅ Use: `useLogSync` hook (frontend) / `syncLogs()` service (backend)
-- ❌ Never: Call append/load functions individually
-- 📖 Reference: `docs/log-sync-architecture.md`
+    <pattern name="Database Access">
+      <models>Sequelize models in /electron/module/*/model.ts files</models>
+      <services>Services wrap DB operations with Result types for error handling</services>
+      <concurrency>DB queue system prevents concurrent write issues</concurrency>
+    </pattern>
 
-### 🚨 Task Completion Process
-```
-1. Code Implementation
-2. yarn lint:fix
-3. yarn lint
-4. yarn test
-5. Task Completion
-```
+    <pattern name="Photo Processing">
+      <exif>EXIF data extraction using exiftool-vendored</exif>
+      <thumbnails>Image processing with sharp for thumbnails</thumbnails>
+      <association>Automatic association with VRChat log files based on timestamps</association>
+    </pattern>
 
-### Key Architectural Patterns
+    <pattern name="Timezone Handling" priority="critical" jp="日時データ整合性必須">
+      <principle>全ての日時データをローカルタイムとして統一処理</principle>
+      <log-parsing>parseLogDateTime() でVRChatログをローカルタイムとして解釈</log-parsing>
+      <frontend-dates>new Date('YYYY-MM-DDTHH:mm:ss') でローカルタイム処理</frontend-dates>
+      <database-storage>SequelizeがDateオブジェクトを自動的にUTCで保存</database-storage>
+      <utc-conversion>JavaScript Dateオブジェクトがローカルタイム→UTC変換を自動実行</utc-conversion>
+      <photo-timestamps>写真ファイル名の日時もローカルタイムとして処理</photo-timestamps>
+      <test-pattern>electron/module/vrchatLog/parsers/timezone.test.ts</test-pattern>
+      <critical-rule>日時処理では常にローカルタイムベースで実装、UTC変換はSequelize/JSに委ねる</critical-rule>
+    </pattern>
 
-1. **tRPC Communication**: All communication between Electron main and renderer processes goes through tRPC routers defined in `electron/api.ts`
+    <pattern name="ValueObject" priority="critical" jp="型安全・カプセル化必須">
+      <type-only-export>
+        <![CDATA[
+        class MyValueObject extends BaseValueObject<'MyValueObject', string> {}
+        export type { MyValueObject };  // ✅ 型のみエクスポート
+        export { MyValueObject };        // ❌ クラスエクスポート禁止
+        ]]>
+      </type-only-export>
+      <instance-creation>
+        <![CDATA[
+        const obj = MyValueObjectSchema.parse(value);  // ✅ Zodスキーマ経由
+        const obj = new MyValueObject(value);          // ❌ 直接new禁止
+        ]]>
+      </instance-creation>
+      <validation-functions>
+        <![CDATA[
+        export const isValidMyValueObject = (value: string): boolean => {...}
+        ]]>
+      </validation-functions>
+      <lint-enforcement>yarn lint:valueobjects で自動検証</lint-enforcement>
+    </pattern>
 
-2. **Error Handling** (型安全・構造化システム): 
-   - **3層エラーアーキテクチャ**:
-     - Service層: neverthrow Result pattern (`Result<T, E>`)
-     - tRPC層: UserFacingError with structured info (`code`/`category`/`userMessage`)
-     - Frontend層: parseErrorFromTRPC + Toast variant selection
-   - **構造化エラー情報**:
-     ```typescript
-     interface StructuredErrorInfo {
-       code: string;           // 'FILE_NOT_FOUND', 'DATABASE_ERROR', etc.
-       category: string;       // ERROR_CATEGORIES enum値
-       userMessage: string;    // ユーザー向けメッセージ
-     }
-     ```
-   - **エラーマッピング with ts-pattern**: 
-     - `electron/lib/errorHelpers.ts`: Result→UserFacingError bridging
-     - ALL mappings MUST have `default` case (prevent "予期しないエラー")
-     - Type-safe error handling with `match()` from ts-pattern
-   - **Frontend Error Processing**:
-     - `parseErrorFromTRPC()`: Extract structured error info from tRPC responses
-     - Toast variant mapping: `getToastVariant(category)` with ts-pattern
-     - Categories: `FILE_NOT_FOUND`→warning, `DATABASE_ERROR`→destructive, etc.
-   - **Technical Detail Hiding**:
-     - UserFacingError: Hide stack traces from user-facing messages
-     - tRPC errorFormatter: Include debug info only for non-UserFacingErrors
-     - Frontend: Show only `userMessage`, not technical details
-   - **Error Category → Toast Variant Mapping**:
-     ```typescript
-     // src/v2/App.tsx getToastVariant()
-     FILE_NOT_FOUND → 'warning'        // 準正常系
-     VALIDATION_ERROR → 'warning'      // ユーザー入力問題
-     SETUP_REQUIRED → 'default'        // 初期設定
-     PERMISSION_DENIED → 'destructive' // システムエラー
-     DATABASE_ERROR → 'destructive'    // 重大エラー
-     NETWORK_ERROR → 'destructive'     // 重大エラー
-     ```
+    <pattern name="Electron Module Import" priority="critical" jp="Playwright テスト互換性必須">
+      <forbidden>トップレベルで electron の app, BrowserWindow 等をインポート</forbidden>
+      <example-bad>
+        <![CDATA[
+        // ❌ NEVER: Playwright テストでクラッシュ
+        import { app } from 'electron';
+        const logPath = app.getPath('logs');
+        ]]>
+      </example-bad>
+      <example-good>
+        <![CDATA[
+        // ✅ OK: 遅延評価または動的インポート
+        const getLogPath = () => {
+          try {
+            const { app } = require('electron');
+            return app.getPath('logs');
+          } catch {
+            return '/tmp/test-logs';
+          }
+        };
+        ]]>
+      </example-good>
+      <common-module-warning>logger.ts など共通モジュールでのトップレベルインポートは全体に影響</common-module-warning>
+      <symptom>Playwright テストで electronApplication.firstWindow: Timeout エラー</symptom>
+      <reference>docs/troubleshooting-migration-playwright-timeout.md</reference>
+    </pattern>
+  </architectural-patterns>
 
-3. **Database Access**: 
-   - Sequelize models in `/electron/module/*/model.ts` files
-   - Services wrap DB operations with Result types for error handling
-   - DB queue system prevents concurrent write issues
+  <testing>
+    <database-pattern>
+      <![CDATA[
+      describe('service with database', () => {
+        beforeAll(async () => {
+          client.__initTestRDBClient();
+        }, 10000);
+        
+        beforeEach(async () => {
+          await client.__forceSyncRDBClient();
+        });
+        
+        afterAll(async () => {
+          await client.__cleanupTestRDBClient();
+        });
 
-4. **Photo Processing**:
-   - EXIF data extraction using exiftool-vendored
-   - Image processing with sharp for thumbnails
-   - Automatic association with VRChat log files based on timestamps
+        it('test case', async () => {
+          // Use existing service functions for test data
+          // Use datefns.parseISO for dates
+        });
+      });
+      ]]>
+      <reference>electron/module/logInfo/service.spec.ts</reference>
+    </database-pattern>
 
-5. **🚨 Log Synchronization Architecture** (CRITICAL - データ整合性必須):
-   - **Execution Order**: `appendLoglines` → `loadLogInfo` → cache invalidation (厳守必須)
-   - **Data Corruption Risk**: 順序違反で写真が間違ったワールドに分類される
-   - **Sync Modes**: 
-     - `FULL`: Complete processing (初回起動、設定更新時)
-     - `INCREMENTAL`: Delta processing (通常更新、バックグラウンド)
-   - **Unified Pattern**: `useLogSync` hook (frontend) / `syncLogs` service (backend)
-   - **Initial Launch Detection**: 既存ログ件数によるDB状態判定
-   - **Cache Strategy**: startup detection (staleTime: 0) vs regular data (5min)
-   - **Reference**: `docs/log-sync-architecture.md` (詳細実装パターン)
+    <integration-test-separation>
+      <unit-tests>*.test.ts</unit-tests>
+      <integration-tests>*.integration.test.ts</integration-tests>
+      <reason>Separating integration tests prevents database initialization conflicts</reason>
+      <example>logInfoController.test.ts (mocked) vs logInfoController.integration.test.ts (real DB)</example>
+    </integration-test-separation>
 
-6. **🚨 Timezone Handling Architecture** (CRITICAL - 日時データ整合性必須):
-   - **Consistent Local Time Processing**: 全ての日時データをローカルタイムとして統一処理
-   - **Log Parsing**: `parseLogDateTime()` でVRChatログをローカルタイムとして解釈
-   - **Frontend Dates**: フロントエンド日付入力は `new Date('YYYY-MM-DDTHH:mm:ss')` でローカルタイム処理
-   - **Database Storage**: SequelizeがDateオブジェクトを自動的にUTCで保存
-   - **UTC Conversion**: JavaScript Dateオブジェクトがローカルタイム→UTC変換を自動実行
-   - **Photo Timestamps**: 写真ファイル名の日時もローカルタイムとして処理
-   - **Test Pattern**: `electron/module/vrchatLog/parsers/timezone.test.ts` に統一パターン
-   - **Critical Rule**: 日時処理では常にローカルタイムベースで実装、UTC変換はSequelize/JSに委ねる
+    <vitest-mock-issues>
+      <issue>Electron app mocking may require vi.mock('electron') before other mocks</issue>
+      <issue>Complex file system mocks may fail; use describe.skip() for problematic tests</issue>
+      <issue>Dynamic imports don't always solve mock timing issues in vitest</issue>
+    </vitest-mock-issues>
 
-7. **🚨 Conditional Logic with ts-pattern** (型安全・表現力向上必須):
-   - **Mandatory Usage**: Replace ALL `if` statements with `match()` from ts-pattern
-   - **Priority Targets**:
-     - Error handling conditionals (`instanceof Error`, error code comparison)
-     - Enum/string literal comparisons (`match(status).with('pending', ...)`)
-     - Type guards and `instanceof` checks (`match(obj).with(P.instanceOf(Error), ...)`)
-     - Nested if-else chains
-   - **Required Pattern**:
-     ```typescript
-     import { match, P } from 'ts-pattern';
-     
-     // Replace: if (error instanceof Error) return handleError(error);
-     return match(error)
-       .with(P.instanceOf(Error), (err) => handleError(err))
-       .otherwise((err) => { throw err; });
-     ```
-   - **Exceptions (NO ts-pattern needed)**:
-     - Simple boolean checks (`if (isLoading)`)
-     - Complex business logic conditions
-     - Test assertions
-   - **Benefits**: Type inference, exhaustiveness checking, better readability
+    <module-path-issues priority="critical" jp="相対パスの確認必須">
+      <example>electron/module/vrchatLog/ → electron/lib/ = ../../lib/ (NOT ../../../lib/)</example>
+      <symptom>TypeError: The "path" argument must be of type string. Received undefined</symptom>
+      <cause>モックされた関数が undefined を返す（パスが間違っているため）</cause>
+      <solution>import パスと vi.mock() パスの両方を修正</solution>
+    </module-path-issues>
+  </testing>
 
+  <git-workflow>
+    <branch-format>
+      <pattern>{issue-number}/{type}/{summary}</pattern>
+      <example>123/feat/add-user-search</example>
+      <types>feat, fix, chore, docs, style, refactor, perf, test</types>
+    </branch-format>
+  </git-workflow>
 
-### Auto-Generated Files (変更禁止)
-- `src/assets/licenses.json`
-- `yarn.lock`
-- `CHANGELOG.md`
-- `debug/` directory
+  <auto-generated-files jp="変更禁止">
+    <file>src/assets/licenses.json</file>
+    <file>yarn.lock</file>
+    <file>CHANGELOG.md</file>
+  </auto-generated-files>
 
-### Git Branch Format
-`{issue-number}/{type}/{summary}`
-Example: `123/feat/add-user-search`
+  <mcp-servers>
+    <server name="IDE" id="mcp__ide__">
+      <description>VS Code統合機能を提供。エディタの診断情報取得やコード実行に使用。</description>
+      <functions>getDiagnostics, executeCode</functions>
+    </server>
 
-Types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`
+    <server name="Context7" id="mcp__context7__">
+      <description>最新のライブラリドキュメント取得用。</description>
+      <usage>
+        <step order="1">resolve-library-id: ライブラリ名からContext7互換IDを取得</step>
+        <step order="2">get-library-docs: IDを使用してドキュメントを取得</step>
+      </usage>
+      <supported-libraries>React, Next.js, Supabase, MongoDB等の主要ライブラリ</supported-libraries>
+    </server>
 
-## Environment Requirements
-- Node.js 20 LTS
-- Yarn 4 (npm禁止)
+    <server name="Serena" id="mcp__serena__">
+      <description>セマンティックコード解析とシンボルベースの編集。</description>
+      <functions>
+        <symbol-ops>find_symbol, replace_symbol_body, insert_before_symbol, insert_after_symbol, find_referencing_symbols, get_symbols_overview</symbol-ops>
+        <memory-ops>write_memory, read_memory, onboarding</memory-ops>
+      </functions>
+      <principles>
+        <principle>ファイル全体読み込みは避け、シンボル単位で操作</principle>
+        <principle>相対パスではなくシンボルの名前パスで指定</principle>
+        <principle>ts-patternによるマッチングを活用</principle>
+      </principles>
+    </server>
 
-## Database Testing Pattern
-
-```typescript
-describe('service with database', () => {
-  beforeAll(async () => {
-    client.__initTestRDBClient();
-  }, 10000);
-  
-  beforeEach(async () => {
-    await client.__forceSyncRDBClient();
-  });
-  
-  afterAll(async () => {
-    await client.__cleanupTestRDBClient();
-  });
-
-  it('test case', async () => {
-    // Use existing service functions for test data
-    // Use datefns.parseISO for dates
-  });
-});
-```
-
-Reference: `electron/module/logInfo/service.spec.ts`
-
-## Test Organization Patterns
-
-### Integration Test Separation
-- Unit tests with mocks: `*.test.ts`
-- Database integration tests: `*.integration.test.ts`
-- Separating integration tests prevents database initialization conflicts in test runners
-
-Example: `logInfoController.test.ts` (mocked) vs `logInfoController.integration.test.ts` (real DB)
-
-### Vitest Mock Issues
-- Electron app mocking may require `vi.mock('electron')` before other mocks
-- Complex file system mocks may fail; use `describe.skip()` for problematic tests
-- Dynamic imports don't always solve mock timing issues in vitest
-
-### 🚨 Module Path Issues in Tests
-- **相対パスの確認必須**: テストファイルからのモジュールパスを正確に計算
-- **Example**: `electron/module/vrchatLog/` → `electron/lib/` = `../../lib/` (NOT `../../../lib/`)
-- **症状**: `TypeError: The "path" argument must be of type string. Received undefined`
-- **原因**: モックされた関数が `undefined` を返す（パスが間違っているため）
-- **解決**: import パスと vi.mock() パスの両方を修正
-
-### 🚨 ValueObject Pattern (型安全・カプセル化必須)
-- **Type-Only Export Pattern**: ValueObjectクラスは型のみエクスポート
-  ```typescript
-  class MyValueObject extends BaseValueObject<'MyValueObject', string> {}
-  export type { MyValueObject };  // ✅ 型のみエクスポート
-  export { MyValueObject };        // ❌ クラスエクスポート禁止
-  ```
-- **Instance Creation**: Zodスキーマ経由でのみインスタンス化
-  ```typescript
-  const obj = MyValueObjectSchema.parse(value);  // ✅
-  const obj = new MyValueObject(value);          // ❌ 直接new禁止
-  ```
-- **Validation Functions**: 静的メソッドは独立関数として定義
-  ```typescript
-  export const isValidMyValueObject = (value: string): boolean => {...}
-  ```
-- **Lint Enforcement**: `yarn lint:valueobjects` で自動検証
-- **Benefits**: カプセル化強化、不正なインスタンス生成防止
-
-### 🚨 Electron Module Import Pattern (CRITICAL - Playwright テスト互換性必須)
-- **トップレベル import 禁止**: `electron` の `app`, `BrowserWindow` 等をトップレベルでインポートしない
-  ```typescript
-  // ❌ NEVER: Playwright テストでクラッシュ
-  import { app } from 'electron';
-  const logPath = app.getPath('logs');
-  
-  // ✅ OK: 遅延評価または動的インポート
-  const getLogPath = () => {
-    try {
-      const { app } = require('electron');
-      return app.getPath('logs');
-    } catch {
-      return '/tmp/test-logs';
-    }
-  };
-  ```
-- **共通モジュールは特に注意**: `logger.ts` など多くのモジュールから使用される共通モジュールでトップレベルインポートすると、依存する全モジュールが影響を受ける
-- **動的インポートの落とし穴**: `await import()` を使っても、インポート先がトップレベルで Electron を使用していれば同じ問題が発生
-- **症状**: Playwright テストで `electronApplication.firstWindow: Timeout` エラー
-- **Reference**: `docs/troubleshooting-migration-playwright-timeout.md`
-
-## MCP Server Usage Guidelines
-
-### 1. IDE MCP Server (`mcp__ide__`)
-VS Code統合機能を提供。エディタの診断情報取得やコード実行に使用。
-- `getDiagnostics`: TypeScriptエラーや警告を取得
-- `executeCode`: Jupyter notebookでのPythonコード実行
-
-### 2. Context7 MCP Server (`mcp__context7__`)
-最新のライブラリドキュメント取得用。
-- **使用手順**:
-  1. `resolve-library-id`: ライブラリ名からContext7互換IDを取得
-  2. `get-library-docs`: IDを使用してドキュメントを取得
-- **対応ライブラリ**: React, Next.js, Supabase, MongoDB等の主要ライブラリ
-
-### 3. Serena MCP Server (`mcp__serena__`)
-セマンティックコード解析とシンボルベースの編集。
-- **主要機能**:
-  - `find_symbol`: 名前パスによるシンボル検索
-  - `replace_symbol_body`: シンボル全体の置換
-  - `insert_before_symbol`/`insert_after_symbol`: シンボル前後への挿入
-  - `find_referencing_symbols`: シンボルの参照箇所検索
-  - `get_symbols_overview`: ファイル内シンボルの概要取得
-- **メモリ管理**:
-  - `write_memory`: プロジェクト情報の保存
-  - `read_memory`: 保存情報の読み取り
-  - `onboarding`: 初回プロジェクト分析
-- **使用原則**:
-  - ファイル全体読み込みは避け、シンボル単位で操作
-  - 相対パスではなくシンボルの名前パスで指定
-  - ts-patternによるマッチングを活用
-
-### MCP Server選択の指針
-- **ドキュメント参照が必要**: Context7を使用
-- **コード解析・編集**: Serenaのシンボルツールを優先
-- **エディタ診断**: IDE MCPサーバーを使用
-- **ファイル操作**: 内蔵ツール（Read, Write, Edit）を使用
-
-## CLAUDE.md 更新ルール
-
-以下の場合に更新:
-- データ整合性に関わる重要パターンの発見
-- データ破損やバグを防ぐ制約の発見
-- 新しい技術スタックやアーキテクチャパターンの導入
-- MCP Server構成の変更
-
-更新原則: Critical情報を簡潔に記載、詳細は別ドキュメントへ参照
+    <selection-guidelines>
+      <guideline condition="ドキュメント参照が必要">Context7を使用</guideline>
+      <guideline condition="コード解析・編集">Serenaのシンボルツールを優先</guideline>
+      <guideline condition="エディタ診断">IDE MCPサーバーを使用</guideline>
+      <guideline condition="ファイル操作">内蔵ツール（Read, Write, Edit）を使用</guideline>
+    </selection-guidelines>
+  </mcp-servers>
+</claude-instructions>

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@
   <a href="https://github.com/tktcorporation/vrchat-albums/releases">
     <img src="https://img.shields.io/github/v/release/tktcorporation/vrchat-albums?label=latest%20release" alt="Latest Release">
   </a>
-  <a href="https://github.com/tktcorporation/vrchat-albums/blob/main/LICENSE">
-    <img src="https://img.shields.io/github/license/tktcorporation/vrchat-albums" alt="License">
-  </a>
   <a href="https://github.com/tktcorporation/vrchat-albums/issues">
     <img src="https://img.shields.io/github/issues/tktcorporation/vrchat-albums" alt="Issues">
   </a>
@@ -97,42 +94,10 @@
 ### Q: データのバックアップはどこに保存されますか
 **A:** エクスポート時に指定したフォルダに、日時付きのサブフォルダが作成されて保存されます。
 
-## 🐛 トラブルシューティング
-
-問題が発生した場合は、以下を試してください：
-
-1. アプリを再起動する
-2. 設定画面でフォルダパスを確認する
-3. [Issues](https://github.com/tktcorporation/vrchat-albums/issues)で既知の問題を確認する
-
-## 🛠️ 技術スタック
-
-- **Electron**: クロスプラットフォームのデスクトップアプリケーションフレームワーク
-- **React**: ユーザーインターフェース構築のための JavaScript ライブラリ
-- **Vite**: 高速なフロントエンドビルドツール
-- **tRPC**: 型安全な API 開発のためのフレームワーク
-- **SQLite**: 軽量なローカルデータベース
-- **Tailwind CSS**: ユーティリティファーストの CSS フレームワーク
-- **Vitest**: Vite 上で動作するユニットテストフレームワーク
-
 ## 🤝 コントリビューション
 
 バグ報告、機能提案、プルリクエストを歓迎します！
 詳細は[CONTRIBUTING.md](CONTRIBUTING.md)をご覧ください。
-
-### 開発に参加する
-
-```bash
-# リポジトリをクローン
-git clone https://github.com/tktcorporation/vrchat-albums.git
-cd vrchat-albums
-
-# 依存関係をインストール
-yarn install
-
-# 開発サーバーを起動
-yarn dev
-```
 
 ## 📄 ライセンス
 


### PR DESCRIPTION
## Summary
- CLAUDE.mdをXML形式に変換し、構造化を改善
- mise.tomlにXML検証ツール(fxp-cli)を追加
- README.mdから重複セクションを削除してシンプル化

## Changes
- 📝 CLAUDE.mdをXML形式に変換
  - MCP サーバー情報を追加
  - 構造を階層化して可読性を向上
- 🔧 mise.tomlにfxp-cliを追加（CLAUDE.mdのXML検証用）
- 🧹 README.mdの重複セクションを削除
  - ライセンスバッジ
  - トラブルシューティング
  - 技術スタック
  - 開発参加手順

## Test plan
- [x] XML形式のCLAUDE.mdが正しく解析される
- [x] `cat CLAUDE.md | fxp val` でXML検証が通る

🤖 Generated with [Claude Code](https://claude.ai/code)