### PR TITLE
chore: コンテナ環境でのElectron起動に--no-sandboxオプションを追加

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -16,7 +16,7 @@ yarn build:electron
 # ビルドが成功したら、Electronを起動
 if [ $? -eq 0 ]; then
   echo "Starting Electron..."
-  electron . --disable-gpu
+  electron . --disable-gpu --no-sandbox
 else
   echo "Electron build failed"
 fi


### PR DESCRIPTION
## Summary
- コンテナ環境でElectronが起動しない問題を修正
- 開発環境のdev.shスクリプトに`--no-sandbox`オプションを追加

## 背景
Electron 34.5系へのアップデート後、コンテナ環境でSUIDサンドボックスの権限エラーが発生：
```
The SUID sandbox helper binary was found, but is not configured correctly.
```

## 原因
- Electron 34.5でChromiumのサンドボックス権限チェックが厳格化
- コンテナ環境ではSUID権限の設定が制限される

## 対応
- 開発環境限定で`--no-sandbox`オプションを追加
- 本番環境には影響なし（コンテナ環境でのみ必要）

## Test plan
- [x] コンテナ環境でElectronが正常に起動することを確認
- [x] 開発環境での動作に問題がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development startup to improve compatibility by launching the app without OS sandbox in Electron during local runs.
  * Enhances stability on systems with sandbox restrictions when starting the app in development mode.
  * No changes to production behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->